### PR TITLE
chore: promote develop docs roadmap to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Note記事のURLまたはユーザー名を入力し、ローカルLLMが新し�
 
 今後の大規模改修方針は [ADR 0001](docs/adrs/0001-three-phase-local-article-generation.md) と [3フェーズ実装計画](docs/implementation-plans/three-phase-local-article-generation.md) に整理しています。単一フォームで記事を生成する方式から、文体分析、記事条件の一問一答、記事生成と評価の3フェーズへ移行します。
 
+ADR 0001 を踏まえた次の進化方針は [ADR 0002 — Multi-Persona, Multi-Format Article Generation](docs/adrs/0002-multi-persona-multi-format-extension.md) と [Multi-persona / multi-format 実装計画](docs/implementation-plans/multi-persona-multi-format.md) にまとめています。てりすけ本人と架空キャラ「宇宙野クラウディア」を別人格として扱い、note / cor-jp.com ブログ / Zenn / Qiita / ホームページHTML を切り替え可能にします。
+
 実装 issue と ADR の対応、各層の責務、テスト条件は [Issue and ADR guardrails](docs/implementation-plans/issue-adr-guardrails.md) にまとめています。
 
 ## 主な機能

--- a/docs/adrs/0001-three-phase-local-article-generation.md
+++ b/docs/adrs/0001-three-phase-local-article-generation.md
@@ -4,7 +4,7 @@ Date: 2026-05-01
 
 ## Status
 
-Accepted
+Accepted. Extended by [ADR 0002](0002-multi-persona-multi-format-extension.md), which adds the orthogonal axes of author persona and output format on top of the three-phase pipeline. The phases described below remain authoritative; the registries and strategies introduced by ADR 0002 plug into them rather than replacing them.
 
 ## Context
 

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -1,0 +1,233 @@
+# ADR 0002: Multi-Persona, Multi-Format Article Generation
+
+Date: 2026-05-02
+
+## Status
+
+Accepted. Extends and partially supersedes [ADR 0001](0001-three-phase-local-article-generation.md). The three-phase workflow (style analysis → interview → draft) is preserved. This ADR adds two orthogonal axes — **author persona** and **output format** — and reshapes UX, persistence, and prompt construction accordingly.
+
+## Context
+
+ADR 0001 produced a working three-phase pipeline for `cor_instrument` (Terisuke) on note.com. Real usage by the project owner exposed three structural gaps:
+
+1. **The owner publishes under multiple identities and to multiple platforms.**
+   - Terisuke (本人): [note.com/cor_instrument](https://note.com/cor_instrument), [cor-jp.com/blog](https://cor-jp.com/blog/) — reflective entrepreneur essays mixed with technical experience reports. First person 「僕」「私」, narrative arcs ("～した話", "～てしまった件"), philosophical framing.
+   - Cloudia / 宇宙野クラウディア (架空キャラクター, also operated by the owner): [zenn.dev/cloudia](https://zenn.dev/cloudia), [qiita.com/Cloudia_Cor_Inc](https://qiita.com/Cloudia_Cor_Inc) — character-branded technical tutorials. Hakata-ben (博多弁) flavour, exclamation-driven titles ("クラウディア流！…", "AI探検記【前編】〜最強のお助けAIを探せ！〜"), strong code-block density.
+   - Treating these as one author profile contaminates the style guide and produces drafts that read as neither voice.
+
+2. **The output format is hard-coded to "note.com paste-ready Markdown article".**
+   - `internal/domain/article/draft.go:25-35` requires a `# title` first line and rejects code fences.
+   - `internal/application/draft/prompt.go:12-51` injects "Noteにそのまま貼り付けられる日本語Markdown記事" into every system message.
+   - `internal/infrastructure/note/fetcher.go:234-246` rejects any host other than `note.com` for source ingestion.
+   - HTML homepage sections, Zenn/Qiita Markdown articles (which carry frontmatter), and Astro-blog posts cannot be produced today.
+
+3. **The current UX does not feel like working with a writing partner.**
+   - The interview is a forward-only, edit-locked Q&A; users cannot revise an earlier answer.
+   - The completed brief is rendered as `JSON.stringify` (`static/js/script.js:178`); accumulated knowledge is not legible.
+   - The draft textarea is `readonly` (`static/index.html:153`); there is no per-section regenerate.
+   - The full-screen spinner blocks the page during every LLM call; nothing streams.
+   - There is no visible history of past style profiles or past sessions; reuse is invisible.
+
+The user's stated comparators are Claude, ChatGPT, and Gemini chat UIs — continuous transcripts with editable history, streaming output, and a side-pinned working artifact.
+
+## Decision
+
+Add two orthogonal first-class concepts to the domain and let the rest of the system depend on them via strategy boundaries.
+
+### Persona
+
+A `Persona` is a named, reusable bundle of:
+
+- one or more `AuthorSource` adapters that supply training material,
+- one canonical `WritingStyleGuide` (regenerable when sources change),
+- a default `OutputFormat` (overridable per article),
+- a default question-set variant for the interview phase,
+- optional preset values for the brief (preferred first person, signature opening patterns, recurring themes, anti-patterns).
+
+Two personas ship pre-loaded:
+
+| Persona | Display name | Sources | Default format | Voice notes |
+|---|---|---|---|---|
+| `terisuke` | てりすけ | `note.com/cor_instrument`, `cor-jp.com/blog/*` | `note_article` | 一人称「僕」/「私」、内省＋実体験ナラティブ、起業・キャリア・AI駆動開発、「～した話」「～てしまった件」 |
+| `cloudia` | 宇宙野クラウディア | `zenn.dev/cloudia`, `qiita.com/Cloudia_Cor_Inc` | `zenn_article` | 一人称「クラウディア」/「うち」、博多弁混じり、感嘆符・【前編】等の装飾、AI/JS/Pythonチュートリアル、感情的訴求 (「劇的に」「最強の」) |
+
+Personas are user-extensible. Adding a third persona requires only registering it (no code changes inside the prompt builder).
+
+### OutputFormat
+
+An `OutputFormat` is a typed strategy with:
+
+- a Markdown/HTML template surface (frontmatter, heading rules, code-fence policy, length envelope),
+- a validator (e.g., Zenn requires frontmatter; note rejects code fences; homepage sections forbid `# title`),
+- a default question-set extension (technical formats add "対象スタック", "実行環境", "想定読者の前提知識"; narrative formats add "導入エピソード", "結末で読者に届けたい感情"),
+- a system-prompt fragment merged into the draft prompt (instead of a single hard-coded fragment).
+
+Formats shipped in v2:
+
+| Format | Validator highlights | Source/target |
+|---|---|---|
+| `note_article` | Existing rules: starts with `# `, no code fences, `ですます調` default | note.com paste |
+| `markdown_blog` | Frontmatter optional, allows code fences, `## ` first heading allowed (Astro blogs at `cor-jp.com/blog`) | cor-jp.com |
+| `zenn_article` | Frontmatter required (`title`, `emoji`, `type`, `topics`, `published`), code fences allowed, technical tone bias | zenn.dev/cloudia |
+| `qiita_article` | Frontmatter required (`title`, `tags`), code blocks expected, technical tone bias | qiita.com/Cloudia_Cor_Inc |
+| `homepage_section` | HTML output, no `# title`, semantic sectioning, CTA placement guidance | static HTML embed |
+
+The two axes compose: any persona can produce any format. The application layer rejects nonsensical combinations only when the persona explicitly excludes a format (configurable, not hard-coded).
+
+### UX direction
+
+The single-page form becomes a **conversation-first workspace**:
+
+- **Left rail**: persona switcher, project history, "previous style guides" picker.
+- **Centre**: chat-style transcript. Past answers are clickable and editable, which forks a new session draft from that point. Deep-dive questions render with the parent question quoted as context.
+- **Right rail (artifact panel)**: live brief card and live draft preview, replacing the current JSON dump. Updates as the conversation progresses.
+- **Streaming**: SSE for follow-up generation and draft generation. The full-screen spinner is removed.
+- **Draft editor**: editable in-place, with "regenerate this section" (selection-based) and "copy to clipboard" buttons for both raw Markdown and rendered HTML output.
+
+The static-JS prototype is preserved as a fallback. The new UX can ship as a progressive overlay (no SPA-framework rewrite required for v2; if desired, a later ADR can introduce one).
+
+### Persistence direction
+
+The flat `data/workflow_store.json` snapshot is replaced by a SQLite-backed store with explicit aggregates:
+
+- `personas` — id, display name, default format, source bundle, current canonical guide id.
+- `author_sources` — persona-scoped fetched articles with raw text snapshot for re-derivation.
+- `writing_style_guides` — versioned per persona; previous versions retained.
+- `projects` — a writing project (e.g., "Q3 cor-jp blog series") that owns multiple articles.
+- `articles` — one target deliverable: persona id, output format, brief id, draft history.
+- `brief_sessions`, `brief_answers` — unchanged in shape, gain a `parent_answer_id` for fork-on-edit.
+- `drafts` — versioned per article with score history.
+
+Acceptance criterion: any prior session can be reopened, its accumulated context shown as a transcript, and a new draft regenerated from any point in history.
+
+This subsumes Issue [#14](https://github.com/terisuke/note_maker/issues/14) (queryable database). Issue [#14](https://github.com/terisuke/note_maker/issues/14) is kept open as the umbrella tracker; the SQLite migration becomes its acceptance.
+
+### Source acquisition direction
+
+`SourceFetcher` becomes a strategy interface with concrete implementations:
+
+- `NoteFetcher` — existing `note.com` page + RSS (kept).
+- `ZennFetcher` — public articles (`https://zenn.dev/{user}/articles/{slug}`) and the user's article list.
+- `QiitaFetcher` — public REST (no auth needed for public posts; respect rate limits).
+- `GenericRSSFetcher` — for Astro/Jekyll/Hugo blogs that expose RSS (cor-jp.com is included here once its RSS is confirmed).
+- `HTMLFetcher` — fallback for arbitrary HTML pages with semantic-content extraction.
+
+Per-fetcher rate-limit and User-Agent policy live alongside each adapter.
+
+## Domain Model Changes
+
+New domain types under `internal/domain`:
+
+- `persona` package
+  - `Persona` (id, display_name, sources, default_format, default_questions_extension)
+  - `PersonaRegistry` (in-memory + persisted, seeded with `terisuke` and `cloudia`)
+- `format` package
+  - `OutputFormat` (id, validator, template fragment, default_question_extension)
+  - `FormatRegistry`
+  - `Validator` interface; per-format implementations (e.g., `NoteValidator`, `ZennValidator`)
+- `domain/article`
+  - `Draft` gains a `format_id`; `NewDraft` dispatches to the format's validator instead of hard-coded rules.
+- `domain/brief`
+  - `ArticleBriefSession` gains `persona_id`, `output_format_id`, `parent_answer_id`.
+  - `FixedQuestions` becomes a base list extended by the persona and the format.
+- `domain/project` (new)
+  - `Project`, `Article` aggregates as defined in the persistence section.
+
+## Application Service Changes
+
+- `AnalyzeAuthorStyleService` accepts a `persona_id` and persists the resulting guide as a new version under that persona; previous versions are preserved.
+- `InterviewService` consults the active persona and format to assemble the question list before the first question.
+- `GenerateDraftService` resolves the prompt template fragment from the format's strategy and merges persona-specific tone hints.
+- New `RegenerateSectionService` accepts a draft id, a section selector (heading anchor or character range), the brief, and the persona+format; returns a candidate replacement for human review.
+- New `StreamingDraftService` produces SSE chunks for the draft phase.
+
+## Infrastructure Changes
+
+- `internal/infrastructure/repository/sqlite` — new package implementing every repository interface; the JSON file repository becomes an export/import utility for portability.
+- `internal/infrastructure/source/{note,zenn,qiita,rss,html}` — per-source fetchers behind a common interface in `internal/domain/source` (or kept under `infrastructure` and bound by interface in `domain/persona`).
+- `internal/infrastructure/llamacpp` — gains streaming (SSE) support; existing non-streaming path retained for tests.
+
+## API Changes
+
+Additions:
+
+- `GET /api/personas` / `POST /api/personas` / `PATCH /api/personas/{id}` — persona CRUD.
+- `GET /api/formats` — read-only registry of available formats.
+- `POST /api/projects` / `GET /api/projects` / `GET /api/projects/{id}` — project management.
+- `GET /api/sessions/{id}/transcript` — chat-style transcript including parent links.
+- `POST /api/sessions/{id}/answers/{answer_id}/edit` — fork-on-edit for past answers.
+- `POST /api/drafts/{id}/regenerate-section` — section-level regenerate.
+- `POST /api/author-style/analyze`, `POST /api/drafts` — gain `Accept: text/event-stream` for streaming.
+
+Existing `/api/generate` remains a compatibility facade.
+
+## Testing Strategy
+
+- Unit tests added per format validator, per persona seed, per fetcher.
+- Integration tests for full transcript edit-and-fork flow.
+- Scenario tests:
+  - `cmd/scenario/persona_terisuke_note` — current behaviour.
+  - `cmd/scenario/persona_terisuke_blog` — new, targets cor-jp blog format.
+  - `cmd/scenario/persona_cloudia_zenn` — new, validates Zenn frontmatter and code-fence presence.
+  - `cmd/scenario/persona_cloudia_qiita` — new.
+- HTTP handler tests added for every endpoint in `internal/handlers/workflow.go` (currently uncovered).
+- Playwright E2E (extends Issue [#13](https://github.com/terisuke/note_maker/issues/13)) covers persona switch, format switch, edit-and-fork, streaming completion, copy-clipboard, regenerate-section.
+
+## Phased Rollout
+
+The full work is broken into four phases tracked by issues. Each phase is independently shippable and behind a UI toggle until ready.
+
+- **Phase A — Conversation UX (1–2 weeks)**
+  - Chat transcript with editable answers, streaming, deep-dive context display, draft editor + per-section regenerate.
+  - Issues: [#17](https://github.com/terisuke/note_maker/issues/17), [#18](https://github.com/terisuke/note_maker/issues/18), [#19](https://github.com/terisuke/note_maker/issues/19), [#20](https://github.com/terisuke/note_maker/issues/20).
+- **Phase B — Multi-persona, multi-format (2–3 weeks)**
+  - Persona registry seeded with `terisuke` and `cloudia`, OutputFormat strategy, source fetcher generalisation, format-aware question sets.
+  - Issues: [#21](https://github.com/terisuke/note_maker/issues/21), [#22](https://github.com/terisuke/note_maker/issues/22), [#23](https://github.com/terisuke/note_maker/issues/23), [#24](https://github.com/terisuke/note_maker/issues/24), [#25](https://github.com/terisuke/note_maker/issues/25).
+- **Phase C — Memory & history (2 weeks, integrates Issue [#14](https://github.com/terisuke/note_maker/issues/14))**
+  - SQLite store with project/article schema, profile/session reuse UI, brief and guide rendered as cards.
+  - Issues: [#26](https://github.com/terisuke/note_maker/issues/26), [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28).
+- **Phase D — Quality & ops**
+  - Handler test coverage, Issue [#11](https://github.com/terisuke/note_maker/issues/11) (style threshold), Issue [#13](https://github.com/terisuke/note_maker/issues/13) (Playwright), Issue [#15](https://github.com/terisuke/note_maker/issues/15) (desktop packaging) follow-up.
+  - Issue: [#29](https://github.com/terisuke/note_maker/issues/29).
+
+Recommended order: A → C → B → D. Phase C is sequenced before B because the persona registry needs durable storage to be useful; running B on the JSON store would force a second migration.
+
+## Tracked issues
+
+Filed 2026-05-02 as part of the PR that introduced this ADR.
+
+- A1 — [#17](https://github.com/terisuke/note_maker/issues/17) Refactor interview UI to chat-style transcript with editable past answers
+- A2 — [#18](https://github.com/terisuke/note_maker/issues/18) Stream LLM responses via SSE for follow-up and draft generation
+- A3 — [#19](https://github.com/terisuke/note_maker/issues/19) Editable draft Markdown + per-section regenerate API
+- A4 — [#20](https://github.com/terisuke/note_maker/issues/20) Surface deep-dive question rationale in prompt and UI
+- B1 — [#21](https://github.com/terisuke/note_maker/issues/21) Introduce Persona and OutputFormat domain concepts (registry + strategy)
+- B2 — [#22](https://github.com/terisuke/note_maker/issues/22) Generalize SourceFetcher beyond note.com (Zenn, Qiita, RSS, HTML)
+- B3 — [#23](https://github.com/terisuke/note_maker/issues/23) Format-specific prompt templates and draft validators (note / markdown_blog / zenn / qiita / homepage_section)
+- B4 — [#24](https://github.com/terisuke/note_maker/issues/24) Seed persona library with `terisuke` and `cloudia` profiles
+- B5 — [#25](https://github.com/terisuke/note_maker/issues/25) Format- and persona-aware fixed question sets
+- C1 — [#26](https://github.com/terisuke/note_maker/issues/26) Replace JSON store with SQLite-backed schema (extends [#14](https://github.com/terisuke/note_maker/issues/14))
+- C2 — [#27](https://github.com/terisuke/note_maker/issues/27) Persona / past-session picker UI
+- C3 — [#28](https://github.com/terisuke/note_maker/issues/28) Render brief and style guide as human-readable cards
+- D1 — [#29](https://github.com/terisuke/note_maker/issues/29) HTTP handler tests for `internal/handlers/workflow.go` (currently 0% coverage)
+
+## Consequences
+
+Positive:
+
+- The product can serve both Terisuke (本人) and Cloudia (キャラクター) without contaminating either voice.
+- Adding a new platform (e.g., Substack, dev.to) becomes one fetcher + one format, not a fork.
+- Memory becomes legible: persona library, project history, and brief cards make accumulated context visible.
+- The conversation feel matches the Claude/ChatGPT/Gemini comparator class.
+
+Tradeoffs:
+
+- Domain surface grows. The win is mitigated by registries and strategy boundaries instead of conditionals.
+- SQLite migration is unavoidable; the JSON file becomes export-only.
+- Streaming requires keeping non-streaming paths for tests; carries minor duplication.
+
+## Rejected alternatives
+
+- **One persona with `style_variant` flag.** Rejected because the two voices share *no* tonal substrate; mixing them in one guide demonstrably degrades both. Two distinct guides are operationally cleaner than one guide with branches.
+- **Output format as a free-text instruction in the brief.** Rejected because validators must be code-enforced (Zenn frontmatter, note `# title`, HTML semantics). Free text gives no validator handle.
+- **Single-page rewrite to React/Vue first.** Rejected as premature; the UX wins (chat transcript, streaming, editable draft) are achievable as progressive enhancements. A framework rewrite is worth a later ADR if profiling shows the static prototype slows iteration.
+- **Skip persona model and let the user paste a custom style guide.** Rejected because re-deriving the guide from real articles is the strongest signal we have; manual paste defeats the style-comparator scoring.

--- a/docs/implementation-plans/issue-adr-guardrails.md
+++ b/docs/implementation-plans/issue-adr-guardrails.md
@@ -1,8 +1,8 @@
 # Issue and ADR guardrails
 
-Date: 2026-05-01
+Date: 2026-05-01 (last updated 2026-05-02)
 
-This document maps GitHub issues to ADR 0001 and defines implementation guardrails.
+This document maps GitHub issues to [ADR 0001](../adrs/0001-three-phase-local-article-generation.md) and [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) and defines implementation guardrails.
 
 ## Issue Map
 
@@ -13,6 +13,15 @@ This document maps GitHub issues to ADR 0001 and defines implementation guardrai
 | [#9](https://github.com/terisuke/note_maker/issues/9) | Draft generation from style guide and brief | Draft Generation | Draft generation must not fetch Note articles; it only consumes `WritingStyleGuide + ArticleBrief`. |
 | [#10](https://github.com/terisuke/note_maker/issues/10) | API, UI, and scenario integration | API Direction / Testing Strategy | `go test ./...` stays offline; network/LLM scenarios require explicit env vars. |
 
+Open issues that ADR 0002 reframes (see [ADR 0002 — Tracked issues](../adrs/0002-multi-persona-multi-format-extension.md#tracked-issues) for the new umbrella):
+
+| Issue | Scope | ADR Section | Guardrail |
+| --- | --- | --- | --- |
+| [#11](https://github.com/terisuke/note_maker/issues/11) | Strict style threshold tuning | ADR 0001 Draft Generation | Thresholds remain code-level; tuning may be revised once `first_person` density is computed per persona (ADR 0002 §Persona). |
+| [#13](https://github.com/terisuke/note_maker/issues/13) | Browser E2E for model config and question CRUD | ADR 0002 §Testing Strategy | Phase D folds persona switch, format switch, edit-and-fork, streaming, regenerate-section into the E2E surface. |
+| [#14](https://github.com/terisuke/note_maker/issues/14) | Persistent queryable database | ADR 0002 §Persistence direction | SQLite migration is the acceptance for #14; multi-persona schema is mandatory. |
+| [#15](https://github.com/terisuke/note_maker/issues/15) | Desktop launcher packaging | Out of ADR 0002 scope | Tracked separately; depends on Phase C completion before packaging makes sense. |
+
 Closed historical issues:
 
 | Issue | Completed Scope | Relation to ADR 0001 |
@@ -21,6 +30,15 @@ Closed historical issues:
 | [#4](https://github.com/terisuke/note_maker/issues/4) | Resilient Note acquisition | Provides article acquisition adapter for author style analysis. |
 | [#5](https://github.com/terisuke/note_maker/issues/5) | DDD boundary split | Provides package boundary precedent. |
 | [#6](https://github.com/terisuke/note_maker/issues/6) | API contract alignment | Existing compatibility endpoint remains while new workflow is added. |
+
+## ADR 0002 Phase Map
+
+The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (A, B, C, D) are tracked as separate issues in the new tranche. Their guardrails extend the rules below:
+
+- Phase A (Conversation UX): no domain changes, only handler streaming + frontend rewrite. Must keep all existing `go test ./...` green without modification.
+- Phase B (Persona / OutputFormat): introduces `internal/domain/persona` and `internal/domain/format`. The note.com host check moves out of application services into `internal/infrastructure/source/note` only.
+- Phase C (SQLite store): repository interfaces stay; only implementations change. JSON-file store becomes import/export utility.
+- Phase D (Quality): handler tests are mandatory before any further endpoint additions land. Coverage gate: `internal/handlers/workflow.go` ≥ 80 %.
 
 ## Architectural Guardrails
 

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -1,0 +1,278 @@
+# Multi-persona, multi-format implementation plan
+
+Date: 2026-05-02
+
+This plan implements [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md). It extends [ADR 0001](../adrs/0001-three-phase-local-article-generation.md) without throwing away its three-phase pipeline.
+
+## Goal
+
+Take Note Maker from "single-persona, single-format note.com generator" to "writing partner that supports the project owner's two operating identities (てりすけ / クラウディア) and at least four publishing targets (note / cor-jp blog / Zenn / Qiita), with a conversation-first UX and durable memory."
+
+## Non-goals (this plan)
+
+- Cloud or multi-tenant deployment. The system stays local-first and single-user.
+- Replacing the three-phase pipeline. Phases stay; orchestration is reshaped.
+- Native desktop packaging. Issue [#15](https://github.com/terisuke/note_maker/issues/15) remains separate.
+- Additional personas beyond the two seeded ones. The registry must support more, but only two ship.
+
+## Phasing
+
+The four phases below match ADR 0002. Each is independently shippable.
+
+| Phase | Goal | Dominant cost | Issues |
+|---|---|---|---|
+| A | Conversation UX upgrade | Frontend + handler streaming | [#17](https://github.com/terisuke/note_maker/issues/17), [#18](https://github.com/terisuke/note_maker/issues/18), [#19](https://github.com/terisuke/note_maker/issues/19), [#20](https://github.com/terisuke/note_maker/issues/20) |
+| B | Persona + Format axes | Domain refactor + new fetchers | [#21](https://github.com/terisuke/note_maker/issues/21), [#22](https://github.com/terisuke/note_maker/issues/22), [#23](https://github.com/terisuke/note_maker/issues/23), [#24](https://github.com/terisuke/note_maker/issues/24), [#25](https://github.com/terisuke/note_maker/issues/25) |
+| C | Memory: SQLite + history UI | Persistence rewrite, extends [#14](https://github.com/terisuke/note_maker/issues/14) | [#26](https://github.com/terisuke/note_maker/issues/26), [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28) |
+| D | Quality & coverage | Tests + thresholds | [#29](https://github.com/terisuke/note_maker/issues/29) (rolls up [#11](https://github.com/terisuke/note_maker/issues/11), [#13](https://github.com/terisuke/note_maker/issues/13)) |
+
+Recommended order: **A → C → B → D**. Phase B benefits from durable storage (Phase C) being in place first, otherwise the JSON store becomes a temporary obstacle for the persona registry.
+
+## Phase A — Conversation UX
+
+### A1 — Chat-style transcript with editable past answers
+
+- Replace the bounded `question-log` div (currently `max-height: 340px`) with a full-height scrolling transcript.
+- Each `BriefAnswer` rendered as a clickable bubble; clicking opens an inline edit affordance.
+- Editing an answer creates a new session that forks at that answer (server: `POST /api/sessions/{id}/answers/{answer_id}/edit`, returns the new `session_id`). Original session is retained for comparison.
+- Visual: question bubbles left-aligned, answers right-aligned; deep-dive questions visually nested under their parent fixed question.
+- Keyboard: `↑` recalls the previous unsubmitted answer; `Cmd/Ctrl+Enter` submits.
+
+Acceptance:
+
+- Editing answer #2 in a 5-answer session produces a new session whose answers list is `[1, 2', …]`.
+- Original session is reachable from the new session via `parent_session_id`.
+
+### A2 — Stream LLM responses via SSE
+
+- Add SSE support to `internal/infrastructure/llamacpp/client.go` (OpenAI-compatible `stream: true`).
+- Wire streaming through the application services for `follow-up generation` and `draft generation`. Style analysis can stay non-streaming (single short call).
+- Frontend: replace global spinner with token-by-token append into the transcript (for follow-up) or into the draft preview (for draft).
+
+Acceptance:
+
+- A 3000-character draft visibly streams; first token < 3s on `gemma4:31b` warm.
+- Network tab shows `text/event-stream` content type with incremental chunks.
+
+### A3 — Editable draft + per-section regenerate
+
+- Make `<textarea id="markdown-output">` writable. Live-sync into the rendered preview via `marked`.
+- Add a "Regenerate this section" button that activates when the cursor is inside a `## ` section. Sends the section heading + the brief + the persona/format to a new `POST /api/drafts/{id}/regenerate-section` endpoint.
+- Add a "Copy" button to the preview tab as well as the markdown tab.
+
+Acceptance:
+
+- Editing the textarea immediately updates the preview.
+- Regenerating section "## 実装" replaces only that subtree of the Markdown; the other sections remain byte-identical.
+
+### A4 — Deep-dive rationale surfaced
+
+- Follow-up prompt (`internal/handlers/workflow.go:437-453`) gains the parent question text and the latest answer summary, plus the active style guide as context.
+- UI renders deep-dive bubbles with a quoted excerpt from the parent answer ("「〇〇」というご回答を踏まえて…").
+- Fallback (rule-based) text uses the same prefix to keep tone consistent.
+
+Acceptance:
+
+- Every deep-dive bubble in the transcript visibly references its parent answer.
+- Falling back to the rule-based path (LLM stub) still produces a contextual prefix.
+
+## Phase B — Persona + OutputFormat
+
+### B1 — Persona and OutputFormat domain concepts
+
+New packages:
+
+- `internal/domain/persona`
+  - types: `Persona`, `PersonaID`, `PersonaSeed`
+  - registry: in-memory + SQLite-backed once Phase C lands
+- `internal/domain/format`
+  - types: `OutputFormat`, `FormatID`, `Validator`
+  - registry: same dual-mode
+
+Hooks:
+
+- `domain/article.NewDraft` accepts `format_id`, dispatches validation to the format's `Validator`.
+- `domain/brief.ArticleBriefSession` gains `persona_id`, `output_format_id`.
+- `application/draft.BuildPrompt` becomes `BuildPrompt(persona, format, guide, brief)`; the function pulls a per-format system fragment instead of the current hard-coded string.
+
+Acceptance:
+
+- `go test ./...` passes with all five formats registered.
+- A unit test exists per format validator (note / markdown_blog / zenn / qiita / homepage_section).
+
+### B2 — SourceFetcher generalisation
+
+New package `internal/domain/source` with:
+
+```go
+type Fetcher interface {
+    FetchProfile(ctx context.Context, ref Ref) (*ProfileSnapshot, error)
+    FetchArticle(ctx context.Context, ref Ref) (*ArticleSnapshot, error)
+    FetchList(ctx context.Context, ref Ref, limit int) ([]ArticleSnapshot, error)
+}
+```
+
+Concrete implementations under `internal/infrastructure/source/`:
+
+- `note/` — extracted from existing `internal/infrastructure/note/fetcher.go`.
+- `zenn/` — public articles + `/{user}/feed`. Robots.txt + 1 req/sec.
+- `qiita/` — public REST API (no auth needed for read-only public posts) + HTML fallback.
+- `rss/` — generic RSS reader for Astro/Jekyll/Hugo blogs.
+- `html/` — generic semantic-content extractor (last resort).
+
+Each fetcher carries its own User-Agent string and rate-limit policy.
+
+Acceptance:
+
+- Scenario test fetches one article from each of {note, zenn, qiita, rss} and produces `tmp/source_fetch/{name}.json`.
+- The note.com host check moves out of the application service into the `note` fetcher only; other hosts route to other fetchers.
+
+### B3 — Format-specific prompt templates and validators
+
+Files:
+
+- `internal/application/draft/templates/note_article.go`
+- `internal/application/draft/templates/markdown_blog.go`
+- `internal/application/draft/templates/zenn_article.go`
+- `internal/application/draft/templates/qiita_article.go`
+- `internal/application/draft/templates/homepage_section.go`
+
+Validators (in `internal/domain/format/validators/`):
+
+- `NoteValidator` — current rules: `# ` first line, no fences, `ですます調` recommendation.
+- `MarkdownBlogValidator` — frontmatter optional, `# ` or `## ` first heading, fences allowed.
+- `ZennValidator` — frontmatter required (`title`, `emoji`, `type ∈ {tech, idea}`, `topics: [...]`, `published: bool`), code fences allowed, no `# ` (Zenn auto-renders title from frontmatter).
+- `QiitaValidator` — frontmatter required (`title`, `tags: [...]`), code fences allowed.
+- `HomepageSectionValidator` — output is HTML, no `# `, requires at least one `<h2>` and one `<p>`, optional CTA `<a>` block.
+
+Acceptance:
+
+- Each validator has a positive and negative unit test.
+- Generating the same brief under different formats produces visibly different drafts: Zenn has frontmatter + many code fences; note has narrative paragraphs and ですます調; homepage_section is HTML with no `# `.
+
+### B4 — Persona library seed
+
+Seed file: `internal/domain/persona/seed.go` (or YAML under `data/personas/`).
+
+```yaml
+- id: terisuke
+  display_name: てりすけ
+  default_format: note_article
+  sources:
+    - kind: note
+      ref: cor_instrument
+    - kind: rss
+      ref: https://cor-jp.com/blog/rss.xml   # confirm URL during implementation
+  voice_notes:
+    first_person: 僕
+    tone: 内省＋実体験ナラティブ
+    title_patterns: ["～した話", "～てしまった件", "【〇〇】"]
+    anti_patterns: ["過度に断定的な表現", "クラウディア風の感嘆符連打"]
+
+- id: cloudia
+  display_name: 宇宙野クラウディア
+  default_format: zenn_article
+  sources:
+    - kind: zenn
+      ref: cloudia
+    - kind: qiita
+      ref: Cloudia_Cor_Inc
+  voice_notes:
+    first_person: クラウディア
+    tone: 博多弁混じりキャラクター解説
+    title_patterns: ["クラウディア流！…", "～探検記【前編】", "～を探せ！"]
+    anti_patterns: ["てりすけ風の内省的書き出し", "断定的な経営論"]
+```
+
+Acceptance:
+
+- A scenario command runs `analyze` for both personas and writes two distinct `WritingStyleGuide` files to `tmp/personas/`.
+- Cross-style score: rebuilding Cloudia's guide from Terisuke's articles produces lower style-similarity than Cloudia's own articles (sanity check that the personas are actually distinct).
+
+### B5 — Format- and persona-aware fixed questions
+
+The fixed nine questions in `static/js/script.js` are extracted server-side into `internal/domain/brief/questions/`:
+
+- `base.go` — questions common to all (theme, reader, exclusions).
+- `narrative.go` — extension for `note_article` + `markdown_blog` (opening_episode, personal_context, expected_reader_action).
+- `technical.go` — extension for `zenn_article` + `qiita_article` (target_stack, runtime_env, prerequisite_knowledge, code_examples, references).
+- `homepage.go` — extension for `homepage_section` (target_conversion, primary_cta, brand_voice).
+
+`InterviewService` composes `base + persona_extension + format_extension` at session start.
+
+Acceptance:
+
+- Starting a `cloudia × zenn_article` session asks technical questions including `target_stack`.
+- Starting a `terisuke × note_article` session is byte-identical to the current question set.
+- Custom questions added via the existing config UI are appended after the composed list.
+
+## Phase C — Memory & history
+
+### C1 — SQLite store (extends Issue [#14](https://github.com/terisuke/note_maker/issues/14))
+
+- New package `internal/infrastructure/repository/sqlite` using `modernc.org/sqlite` (pure Go, no CGO) or `mattn/go-sqlite3` if CGO is acceptable.
+- Schema migrations under `internal/infrastructure/repository/sqlite/migrations/` numbered `0001_*.sql`, applied at boot via a tiny in-process migrator.
+- Tables (minimum): `personas`, `author_sources`, `writing_style_guides` (versioned), `projects`, `articles`, `brief_sessions`, `brief_answers` (with `parent_answer_id`), `drafts` (versioned).
+- The existing JSON file becomes an export/import utility. On first boot, if the JSON file exists, it is imported.
+- Default DB path: `data/note_maker.db` (gitignored).
+
+Acceptance:
+
+- All repository interfaces have SQLite implementations. Existing in-memory implementations remain for tests.
+- `go test ./...` passes against both implementations.
+- Re-opening the app after a restart shows past projects, sessions, and drafts.
+
+### C2 — Persona / past-session picker UI
+
+- Top bar adds a persona switcher (`てりすけ` / `宇宙野クラウディア` / `+ Add persona`).
+- Left rail lists projects; each project expands into its articles.
+- Selecting a past article rehydrates the right-side artifact panel (brief card + draft history).
+- "Start new article from this persona" reuses the current canonical guide for that persona.
+
+Acceptance:
+
+- Switching personas swaps the question set and the default format on the next session start.
+- Re-opening yesterday's session restores the transcript exactly.
+
+### C3 — Brief and guide as human-readable cards
+
+- Replace `JSON.stringify` brief preview with a card stack: theme, reader, must-include (chips), exclusions (chips), opening episode (quote block), tone (badge), expected reader action (callout).
+- Replace `<pre>` guide preview with a structured guide card: first-person badge, recurring themes (chips), opening pattern, conclusion pattern, anti-patterns (warning callouts).
+- Both cards have an "Edit" affordance that updates the underlying brief / guide.
+
+Acceptance:
+
+- Visual: no JSON visible to the end user during normal operation.
+- Editing a brief field updates the in-memory session and persists to SQLite.
+
+## Phase D — Quality & ops
+
+### D1 — Handler tests
+
+`internal/handlers/workflow.go` is 467 lines and currently has zero direct test coverage. This is the highest-leverage gap because every Phase A / B / C change touches it.
+
+- Add `internal/handlers/workflow_test.go` with table-driven tests for each handler: `AnalyzeAuthorStyleHandler`, `CreateBriefSessionHandler`, `AnswerBriefSessionHandler`, `GenerateDraftHandler`, plus the new endpoints introduced by Phases A and B.
+- Use injected fakes for the application services (the existing pattern from `generate_test.go`).
+- Target ≥ 80 % line coverage for `workflow.go`.
+
+Issue [#11](https://github.com/terisuke/note_maker/issues/11) (style threshold tuning) and Issue [#13](https://github.com/terisuke/note_maker/issues/13) (Playwright E2E) are tracked separately but their acceptance criteria are folded into Phase D's exit gate.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Zenn / Qiita ToS or rate limits restrict scraping | Use public, robots-respecting endpoints first; cache aggressively; document UA string per fetcher. |
+| Cloudia voice cross-contaminates Terisuke's guide if persistence schema is wrong | Persona id is a NOT NULL FK on every guide and answer. Tests assert that switching personas does not leak guide ids. |
+| SQLite migration breaks the user's current JSON store | First-boot importer + retain the JSON file for fallback for two releases. |
+| Streaming complicates handler tests | Keep the non-streaming path as the canonical test vector; stream tests use a goldenfile of concatenated chunks. |
+| Format-aware question explosion confuses users | Default question count stays close to current; format extensions are clearly labelled in the UI. |
+
+## Out-of-scope reminders
+
+- A native chat-LLM "free-form" mode where the user can ask the bot anything is **not** in this plan. The interview is still deterministic + targeted deep dives. A free-form mode is a candidate for a future ADR.
+- Multi-user accounts, sharing, and cloud sync are deliberately excluded. They would force a security model and an auth story that the local-first product does not need today.
+- Native HTML preview of the homepage_section format inside the app (visual editor) is out of scope; the format produces validated HTML strings that the user pastes into their site.
+
+## Immediate next implementation step
+
+Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. Start with **[#17](https://github.com/terisuke/note_maker/issues/17)** (chat transcript) on a feature branch off `develop`.


### PR DESCRIPTION
## Summary

Promotes the docs-only multi-persona / multi-format roadmap that was merged into `develop` via PR #31.

Included changes:
- ADR 0002 for Persona × OutputFormat architecture.
- Multi-persona / multi-format implementation plan.
- README, ADR 0001 status, and issue guardrail updates.

## Verification

- PR #31 was clean and its GitHub status checks were successful before merge into `develop`.
- This promotion contains only documentation changes from `develop` to `main`.

No roadmap implementation issues are closed by this promotion PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **アーキテクチャ決定記録（ADR）の拡充**
  * ADR 0002を新規追加し、複数ペルソナと複数出力形式（note、ブログ、Zenn、Qiita、HTML）のサポート方針を定義。
  * 既存の3段階パイプラインを保持しつつ、会話形式UI、SQLiteベースのデータ保存、複数ソース対応を段階的に実装する計画を明記。
  * 実装計画ドキュメントを追加し、4段階フェーズでの機能ロールアウト方針を詳細化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->