### PR TITLE
[codex] Add persona and format draft strategies

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,9 @@ func main() {
 	// APIエンドポイントの設定
 	r.HandleFunc("/api/generate", handlers.GenerateArticleHandler).Methods("POST")
 	r.HandleFunc("/api/models", handlers.ListModelsHandler).Methods("GET")
+	r.HandleFunc("/api/personas", handlers.ListPersonasHandler).Methods("GET")
+	r.HandleFunc("/api/formats", handlers.ListFormatsHandler).Methods("GET")
+	r.HandleFunc("/api/author-style/seed", handlers.SeedAuthorStyleHandler).Methods("POST")
 	r.HandleFunc("/api/author-style/analyze", handlers.AnalyzeAuthorStyleHandler).Methods("POST")
 	r.HandleFunc("/api/author-style/{id}", handlers.GetAuthorStyleHandler).Methods("GET")
 	r.HandleFunc("/api/brief-sessions", handlers.CreateBriefSessionHandler).Methods("POST")

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -4,7 +4,7 @@ Date: 2026-05-02
 
 ## Status
 
-Accepted. Extends and partially supersedes [ADR 0001](0001-three-phase-local-article-generation.md). The three-phase workflow (style analysis → interview → draft) is preserved. This ADR adds two orthogonal axes — **author persona** and **output format** — and reshapes UX, persistence, and prompt construction accordingly.
+Accepted. Implementation started in Phase B. Extends and partially supersedes [ADR 0001](0001-three-phase-local-article-generation.md). The three-phase workflow (style analysis → interview → draft) is preserved. This ADR adds two orthogonal axes — **author persona** and **output format** — and reshapes UX, persistence, and prompt construction accordingly.
 
 ## Context
 
@@ -60,16 +60,17 @@ An `OutputFormat` is a typed strategy with:
 - a Markdown/HTML template surface (frontmatter, heading rules, code-fence policy, length envelope),
 - a validator (e.g., Zenn requires frontmatter; note rejects code fences; homepage sections forbid `# title`),
 - a default question-set extension (technical formats add "対象スタック", "実行環境", "想定読者の前提知識"; narrative formats add "導入エピソード", "結末で読者に届けたい感情"),
-- a system-prompt fragment merged into the draft prompt (instead of a single hard-coded fragment).
+- a system-prompt fragment merged into the draft prompt (instead of a single hard-coded fragment),
+- an embedded Markdown guide for notation details that are too verbose for the registry fragment.
 
 Formats shipped in v2:
 
 | Format | Validator highlights | Source/target |
 |---|---|---|
-| `note_article` | Existing rules: starts with `# `, no code fences, `ですます調` default | note.com paste |
-| `markdown_blog` | Frontmatter optional, allows code fences, `## ` first heading allowed (Astro blogs at `cor-jp.com/blog`) | cor-jp.com |
-| `zenn_article` | Frontmatter required (`title`, `emoji`, `type`, `topics`, `published`), code fences allowed, technical tone bias | zenn.dev/cloudia |
-| `qiita_article` | Frontmatter required (`title`, `tags`), code blocks expected, technical tone bias | qiita.com/Cloudia_Cor_Inc |
+| `note_article` | Starts with `# `, no frontmatter, paste-safe note Markdown subset; plain code fences only when needed | note.com paste |
+| `markdown_blog` | `corsweb2024` Astro frontmatter required (`title`, `description`, `pubDate`, `author`, `category`, `tags`, `lang`, `featured`), Japanese-first, code fences require language | cor-jp.com |
+| `zenn_article` | Frontmatter required (`title`, `emoji`, `type`, `topics`, `published`), Zenn extensions (`:::message`, `:::details`, `@[card]`), `diff language` fences | zenn.dev/cloudia |
+| `qiita_article` | Frontmatter required (`title`, `tags`), Qiita extensions (`:::note`, HTML `details`), `diff_language` fences, `math` code blocks | qiita.com/Cloudia_Cor_Inc |
 | `homepage_section` | HTML output, no `# title`, semantic sectioning, CTA placement guidance | static HTML embed |
 
 The two axes compose: any persona can produce any format. The application layer rejects nonsensical combinations only when the persona explicitly excludes a format (configurable, not hard-coded).
@@ -125,6 +126,9 @@ New domain types under `internal/domain`:
   - `OutputFormat` (id, validator, template fragment, default_question_extension)
   - `FormatRegistry`
   - `Validator` interface; per-format implementations (e.g., `NoteValidator`, `ZennValidator`)
+- `application/draft/format_guides`
+  - embedded Markdown guides for the final draft prompt (`note`, `markdown_blog`, `zenn`, `qiita`, `homepage_section`)
+  - guides encode editor notation differences that are too detailed for the short registry fragment
 - `domain/article`
   - `Draft` gains a `format_id`; `NewDraft` dispatches to the format's validator instead of hard-coded rules.
 - `domain/brief`
@@ -137,7 +141,7 @@ New domain types under `internal/domain`:
 
 - `AnalyzeAuthorStyleService` accepts a `persona_id` and persists the resulting guide as a new version under that persona; previous versions are preserved.
 - `InterviewService` consults the active persona and format to assemble the question list before the first question.
-- `GenerateDraftService` resolves the prompt template fragment from the format's strategy and merges persona-specific tone hints.
+- `GenerateDraftService` resolves the prompt template fragment from the format's strategy, injects the active format's embedded Markdown guide, and merges persona-specific tone hints.
 - New `RegenerateSectionService` accepts a draft id, a section selector (heading anchor or character range), the brief, and the persona+format; returns a candidate replacement for human review.
 - New `StreamingDraftService` produces SSE chunks for the draft phase.
 
@@ -200,9 +204,9 @@ Filed 2026-05-02 as part of the PR that introduced this ADR.
 - A2 — [#18](https://github.com/terisuke/note_maker/issues/18) Stream LLM responses via SSE for follow-up and draft generation
 - A3 — [#19](https://github.com/terisuke/note_maker/issues/19) Editable draft Markdown + per-section regenerate API
 - A4 — [#20](https://github.com/terisuke/note_maker/issues/20) Surface deep-dive question rationale in prompt and UI
-- B1 — [#21](https://github.com/terisuke/note_maker/issues/21) Introduce Persona and OutputFormat domain concepts (registry + strategy)
+- B1 — [#21](https://github.com/terisuke/note_maker/issues/21) Introduce Persona and OutputFormat domain concepts (registry + strategy). Implemented by the first Phase B PR: `internal/domain/persona`, `internal/domain/format`, API selectors, prompt dispatch, and format-aware draft validation.
 - B2 — [#22](https://github.com/terisuke/note_maker/issues/22) Generalize SourceFetcher beyond note.com (Zenn, Qiita, RSS, HTML)
-- B3 — [#23](https://github.com/terisuke/note_maker/issues/23) Format-specific prompt templates and draft validators (note / markdown_blog / zenn / qiita / homepage_section)
+- B3 — [#23](https://github.com/terisuke/note_maker/issues/23) Format-specific prompt templates and draft validators (note / markdown_blog / zenn / qiita / homepage_section). Partially implemented: validators and embedded format guides exist; scenario samples remain open.
 - B4 — [#24](https://github.com/terisuke/note_maker/issues/24) Seed persona library with `terisuke` and `cloudia` profiles
 - B5 — [#25](https://github.com/terisuke/note_maker/issues/25) Format- and persona-aware fixed question sets
 - C1 — [#26](https://github.com/terisuke/note_maker/issues/26) Replace JSON store with SQLite-backed schema (extends [#14](https://github.com/terisuke/note_maker/issues/14))

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -131,23 +131,26 @@ Acceptance:
 
 Files:
 
-- `internal/application/draft/templates/note_article.go`
-- `internal/application/draft/templates/markdown_blog.go`
-- `internal/application/draft/templates/zenn_article.go`
-- `internal/application/draft/templates/qiita_article.go`
-- `internal/application/draft/templates/homepage_section.go`
+- `internal/domain/format/format.go`
+- `internal/application/draft/format_guides/note.md`
+- `internal/application/draft/format_guides/markdown_blog.md`
+- `internal/application/draft/format_guides/zenn.md`
+- `internal/application/draft/format_guides/qiita.md`
+- `internal/application/draft/format_guides/homepage_section.md`
+- `internal/application/draft/format_guides.go`
 
-Validators (in `internal/domain/format/validators/`):
+Validators (in `internal/domain/format`):
 
-- `NoteValidator` — current rules: `# ` first line, no fences, `ですます調` recommendation.
-- `MarkdownBlogValidator` — frontmatter optional, `# ` or `## ` first heading, fences allowed.
-- `ZennValidator` — frontmatter required (`title`, `emoji`, `type ∈ {tech, idea}`, `topics: [...]`, `published: bool`), code fences allowed, no `# ` (Zenn auto-renders title from frontmatter).
-- `QiitaValidator` — frontmatter required (`title`, `tags: [...]`), code fences allowed.
+- `NoteValidator` — `# ` first line, no frontmatter, no Zenn/Qiita-specific extended Markdown; plain fences allowed only when needed.
+- `MarkdownBlogValidator` — `corsweb2024` Astro frontmatter required, `lang: ja`, category limited to `ai | engineering | founder | lab`, `# ` or `## ` first heading, code fences require language.
+- `ZennValidator` — frontmatter required (`title`, `emoji`, `type ∈ {tech, idea}`, `topics: [...]`, `published: bool`), rejects Qiita `:::note` and `diff_language`.
+- `QiitaValidator` — frontmatter required (`title`, `tags: [...]`), rejects Zenn `:::message`, `:::details`, `@[card]`, and `diff language`.
 - `HomepageSectionValidator` — output is HTML, no `# `, requires at least one `<h2>` and one `<p>`, optional CTA `<a>` block.
 
 Acceptance:
 
 - Each validator has a positive and negative unit test.
+- Each registered format has an embedded Markdown guide injected into the final draft prompt.
 - Generating the same brief under different formats produces visibly different drafts: Zenn has frontmatter + many code fences; note has narrative paragraphs and ですます調; homepage_section is HTML with no `# `.
 
 ### B4 — Persona library seed

--- a/docs/research/publishing-platforms.md
+++ b/docs/research/publishing-platforms.md
@@ -1,0 +1,116 @@
+# Publishing platform research
+
+Date: 2026-05-02
+
+This note captures the practical acquisition and generation assumptions behind the first Persona / OutputFormat implementation.
+
+## Sources checked
+
+- Zenn official RSS article: `https://zenn.dev/zenn/articles/zenn-feed-rss`
+- Zenn official CLI guide: `https://zenn.dev/zenn/articles/zenn-cli-guide`
+- Zenn official Markdown guide: `https://zenn.dev/zenn/articles/markdown-guide`
+- Qiita API v2 docs: `https://qiita.com/api/v2/docs`
+- Qiita official Markdown cheat sheet: `https://qiita.com/Qiita/items/c686397e4a0f4f11683d`
+- note Markdown summary article: `https://note.com/akihamitsuki/n/nc7fdbff15bc8`
+- note help center RSS article: `https://www.help-note.com/hc/ja/articles/4402395202841-iframe-RSSで-自分のサイトにnoteを表示する`
+- note help center full RSS article: `https://www.help-note.com/hc/ja/articles/900001001246`
+- Cor.inc blog index: `https://cor-jp.com/blog/`
+- Cor.inc company blog repository: `https://github.com/Cor-Incorporated/corsweb2024`
+- `corsweb2024` files checked through GitHub API:
+  - `BLOG_FORMAT_GUIDE.md`
+  - `src/content/config.ts`
+  - `src/config/categories.ts`
+  - `src/content/blog/ja/ai-driven-development-workflow.md`
+  - `src/content/blog/ja/complete-multilingual-blog-expansion.md`
+  - `src/content/blog/ja/mcp-server-vibe-coding.md`
+  - `src/content/blog/ja/google-cloud-project-migration.md`
+- Public examples:
+  - `https://note.com/cor_instrument`
+  - `https://zenn.dev/cloudia`
+  - `https://qiita.com/Cloudia_Cor_Inc`
+  - `https://cor-jp.com/blog/`
+
+## Acquisition decisions
+
+| Platform | Stable read path | Notes |
+| --- | --- | --- |
+| note | `https://note.com/{user}/rss` plus existing compatibility fetcher | Official help documents RSS. Standard RSS includes excerpts; full RSS is note pro / custom-domain limited. Existing unofficial JSON endpoints stay compatibility-only. |
+| Zenn | `https://zenn.dev/{user}/feed?all=1` | Zenn documents user RSS and `all=1`. Unofficial JSON endpoints exist in the wild but are not the primary contract. |
+| Qiita | Qiita API v2 `GET /api/v2/users/:user_id/items` | Official API returns public item metadata and Markdown body. Unauthenticated clients are rate-limited to 60 requests/hour/IP. |
+| Cor.inc blog | `https://cor-jp.com/rss.xml`, `src/content/blog/ja/*.md` in `corsweb2024`, and semantic HTML fallback | The repo is the best source for exact frontmatter and Markdown body format. Article generation should target `src/content/blog/ja/{slug}.md` first; multilingual expansion can happen later through the existing site pipeline. |
+
+## Initial persona and format split
+
+| Persona | Default format | Practical voice hints |
+| --- | --- | --- |
+| `terisuke` | `note_article` | First person `僕` / `私`; note is for broad-reader technical experiments and reflections; Cor.inc blog is for company technical knowledge reports, implementation decisions, and employee-facing vision sharing. |
+| `cloudia` | `zenn_article` | First person `クラウディア` / `うち`; light Hakata-ben flavour; technical tutorial voice; exclamation-rich titles; code and step-by-step guidance. |
+
+| OutputFormat | Minimum validator |
+| --- | --- |
+| `note_article` | Starts with `# `, no YAML frontmatter, no platform-specific extended Markdown. Plain code fences are allowed only when needed. |
+| `markdown_blog` | Cor.inc Astro blog frontmatter is required: `title`, `description`, `pubDate`, `author`, `category`, `tags`, `lang`, `featured`. Body starts with `# ` or `## `. |
+| `zenn_article` | YAML frontmatter with `title`, `emoji`, `type`, `topics`, `published`; `type` is `tech` or `idea`. |
+| `qiita_article` | YAML frontmatter with `title` and `tags`; code fences allowed. |
+| `homepage_section` | HTML output containing `<section>`, `<h2>`, and `<p>`. |
+
+## Editor notation split
+
+The output mode should also choose notation, not just prose.
+
+| Format | Practical notation policy |
+| --- | --- |
+| note | Keep to the subset that paste-converts reliably in the note editor: `##`, `###`, blockquotes, `-` lists, `1.` lists, `**bold**`, `~~strike~~`, horizontal rule, and plain code fences only when necessary. Avoid frontmatter, HTML, tables, footnotes, math, file-name code fences, and Zenn/Qiita blocks. |
+| Zenn | Use Zenn frontmatter and Zenn extensions: code fences may use `language:filename`; diff highlighting uses `diff language`; tips use `:::message`; warnings use `:::message alert`; collapsible sections use `:::details`; link cards use `@[card](URL)`. |
+| Qiita | Use Qiita frontmatter and Qiita extensions: code fences may use `language:filename`; diff highlighting uses `diff_language`; tips/warnings use `:::note info`, `:::note warn`, `:::note alert`; collapsible sections use HTML `<details><summary>...`; math should prefer `math` code fences or inline `$` backtick notation. |
+
+Generation and validation should reject obvious cross-platform leakage:
+
+- note must not output `:::message`, `:::note`, `:::details`, `@[card]`, HTML tables/details, or math blocks.
+- Zenn must not output Qiita `:::note` or `diff_language` fences.
+- Qiita must not output Zenn `:::message`, `:::details`, `@[card]`, or `diff language` fences.
+
+Implementation note: these notation policies are now captured as embedded Markdown guides under `internal/application/draft/format_guides/`. The final draft prompt injects only the selected format's guide, so the model sees concrete editor rules without receiving unrelated platform examples.
+
+## UX implication
+
+The app should not ask users to remember platform rules. The first usable version therefore exposes:
+
+- writer selector,
+- output target selector,
+- source/voice summary,
+- automatic default format per persona,
+- technical extra questions for Zenn / Qiita,
+- homepage CTA questions for HTML sections,
+- format-specific draft validation before showing the result.
+
+## Cor.inc blog generation target
+
+The company blog is an Astro content collection. The immediate practical output should be copy-pasteable Markdown for `corsweb2024/src/content/blog/ja/{slug}.md`, not an abstract blog draft.
+
+Required frontmatter shape:
+
+```yaml
+---
+title: "記事タイトル"
+description: "50-100文字程度の説明"
+pubDate: 2026-05-02
+author: "Terisuke"
+category: "engineering"
+tags: ["AI", "開発", "知見"]
+lang: "ja"
+featured: false
+isDraft: true
+---
+```
+
+Categories are defined in `src/config/categories.ts`: `ai`, `engineering`, `founder`, `lab`. The older guide text omits `engineering`, but the active Astro schema imports category ids from this config, so the app should follow the config.
+
+Practical style constraints:
+
+- Generate Japanese first: `lang: "ja"`.
+- Use direct company-blog prose: mainly `だ` / `である` / `する`.
+- Keep technical knowledge reports concrete: prerequisites, commands/code, verification result, learned constraints.
+- Keep vision-sharing articles useful for employees: why the decision matters, what behavior should change, and how it connects to company direction.
+- Include code fences only with a language marker.
+- Prefer `isDraft: true` for generated output so the pasted file is safe by default.

--- a/internal/application/brief/service.go
+++ b/internal/application/brief/service.go
@@ -22,6 +22,8 @@ type InterviewService struct {
 type StartSessionInput struct {
 	SessionID      string
 	StyleProfileID string
+	PersonaID      string
+	OutputFormatID string
 	Questions      []domain.ArticleQuestion
 }
 
@@ -43,7 +45,7 @@ func (s *InterviewService) StartSession(input StartSessionInput) (InterviewResul
 	if len(input.Questions) == 0 {
 		input.Questions = domain.FixedQuestions()
 	}
-	session, err := domain.NewArticleBriefSessionWithQuestions(input.SessionID, input.StyleProfileID, input.Questions)
+	session, err := domain.NewArticleBriefSessionWithOptions(input.SessionID, input.StyleProfileID, input.PersonaID, input.OutputFormatID, "", input.Questions)
 	if err != nil {
 		return InterviewResult{}, err
 	}

--- a/internal/application/draft/format_guides.go
+++ b/internal/application/draft/format_guides.go
@@ -1,0 +1,32 @@
+package draft
+
+import (
+	"embed"
+	"io/fs"
+	"strings"
+)
+
+//go:embed format_guides/*.md
+var embeddedFormatGuides embed.FS
+
+const maxFormatGuideRunes = 5000
+
+var formatGuideFiles = map[string]string{
+	"note_article":     "format_guides/note.md",
+	"markdown_blog":    "format_guides/markdown_blog.md",
+	"zenn_article":     "format_guides/zenn.md",
+	"qiita_article":    "format_guides/qiita.md",
+	"homepage_section": "format_guides/homepage_section.md",
+}
+
+func formatGuideMarkdown(formatID string) string {
+	path, ok := formatGuideFiles[strings.TrimSpace(formatID)]
+	if !ok {
+		return ""
+	}
+	content, err := fs.ReadFile(embeddedFormatGuides, path)
+	if err != nil {
+		return ""
+	}
+	return truncateRunes(strings.TrimSpace(string(content)), maxFormatGuideRunes)
+}

--- a/internal/application/draft/format_guides/homepage_section.md
+++ b/internal/application/draft/format_guides/homepage_section.md
@@ -1,0 +1,26 @@
+# Homepage section guide
+
+Use this guide only for `homepage_section` output.
+
+## Output
+
+Return HTML only. Do not output Markdown.
+
+## Required elements
+
+- `<section>`
+- `<h2>`
+- `<p>`
+
+## Recommended elements
+
+- CTA link with `<a>` when the brief includes a target action.
+- Short supporting paragraphs.
+- Clear business value and next action.
+
+## Avoid
+
+- Markdown headings.
+- YAML frontmatter.
+- Code fences.
+- Decorative-only copy.

--- a/internal/application/draft/format_guides/markdown_blog.md
+++ b/internal/application/draft/format_guides/markdown_blog.md
@@ -1,0 +1,53 @@
+# Cor.inc company blog Markdown guide
+
+Use this guide only for `markdown_blog` output.
+
+## Target file
+
+The generated article should be copy-pasteable into:
+
+`corsweb2024/src/content/blog/ja/{slug}.md`
+
+## Required frontmatter
+
+```yaml
+---
+title: "記事タイトル"
+description: "50-100文字程度の説明"
+pubDate: 2026-05-02
+author: "Terisuke"
+category: "engineering"
+tags: ["AI", "開発", "知見"]
+lang: "ja"
+featured: false
+isDraft: true
+---
+```
+
+## Category
+
+Use exactly one of:
+
+- `ai`
+- `engineering`
+- `founder`
+- `lab`
+
+## Body
+
+- Body starts with `# タイトル` or `## タイトル`.
+- Use direct company-blog prose: mainly `だ`, `である`, `する`.
+- Prefer 60-170 lines when the brief allows it.
+- Code fences must specify a language.
+- Include concrete implementation decisions, verification results, or operational lessons.
+
+## Editorial purpose
+
+Use the company blog for:
+
+- company technical knowledge reports,
+- implementation decision records,
+- internal or employee-facing vision sharing,
+- practical lessons that show Cor.inc's capability.
+
+Do not write it like a broad-reader note essay unless the brief explicitly asks for that.

--- a/internal/application/draft/format_guides/note.md
+++ b/internal/application/draft/format_guides/note.md
@@ -1,0 +1,36 @@
+# note Markdown guide
+
+Use this guide only for `note_article` output.
+
+## Goal
+
+Generate paste-ready Japanese Markdown that converts cleanly in the note editor.
+
+## Allowed notation
+
+- `# タイトル` on the first line for the article title.
+- `## 大見出し`.
+- `### 小見出し`.
+- `> 引用`.
+- `- 箇条書き`.
+- `1. 番号付きリスト`.
+- `**太字**`.
+- `~~取り消し線~~`.
+- `---` for a horizontal rule.
+- Plain fenced code blocks only when code is truly needed.
+
+## Avoid
+
+- YAML frontmatter.
+- HTML blocks.
+- Markdown tables.
+- Footnotes.
+- Math blocks or inline math.
+- Zenn notation: `:::message`, `:::details`, `@[card](...)`.
+- Qiita notation: `:::note info`, `:::note warn`, `:::note alert`.
+- Filename code fences such as `ts:src/main.ts`.
+- Diff-specific code fences.
+
+## Writing bias
+
+Use note for broad-reader essays: technical experiments, personal observations, and ideas that should attract readers beyond a narrow implementation context.

--- a/internal/application/draft/format_guides/qiita.md
+++ b/internal/application/draft/format_guides/qiita.md
@@ -1,0 +1,42 @@
+# Qiita Markdown guide
+
+Use this guide only for `qiita_article` output.
+
+## Required frontmatter
+
+```yaml
+---
+title: "記事タイトル"
+tags:
+  - Go
+  - AI
+---
+```
+
+`tags` should use discoverable technology names.
+
+## Structure
+
+- Emphasize reproduction: environment, steps, code, result, troubleshooting, references.
+- Keep explanations concrete enough that another engineer can try them immediately.
+
+## Qiita-specific notation
+
+- Filename code fences: ````rb:app.rb````.
+- Diff highlighting: ````diff_ruby````.
+- Tips and warnings:
+  - `:::note info`
+  - `:::note warn`
+  - `:::note alert`
+- Collapsible details: `<details><summary>...</summary>...</details>`.
+- Math block: ````math````.
+- Inline math: prefer Qiita's backtick dollar notation, e.g. `$`x^2 + y^2 = 1`$`.
+- Markdown tables are allowed. HTML tables are acceptable only when Markdown cannot express the table.
+
+## Avoid
+
+- Zenn `:::message`.
+- Zenn `:::message alert`.
+- Zenn `:::details`.
+- Zenn `@[card](...)`.
+- Zenn diff fences such as `diff ts`.

--- a/internal/application/draft/format_guides/zenn.md
+++ b/internal/application/draft/format_guides/zenn.md
@@ -1,0 +1,42 @@
+# Zenn Markdown guide
+
+Use this guide only for `zenn_article` output.
+
+## Required frontmatter
+
+```yaml
+---
+title: "記事タイトル"
+emoji: "📝"
+type: "tech"
+topics: ["go", "ai"]
+published: false
+---
+```
+
+- `type` must be `tech` or `idea`.
+- `topics` should contain up to 5 short technical tags.
+
+## Structure
+
+- Start body headings at `##`.
+- Prefer reproducible technical explanations: premise, environment, steps, code, result, pitfalls, references.
+
+## Zenn-specific notation
+
+- Filename code fences: ````ts:src/main.ts````.
+- Diff highlighting: ````diff ts````.
+- Tips: `:::message`.
+- Warnings: `:::message alert`.
+- Collapsible details: `:::details`.
+- Link cards: `@[card](https://example.com)`.
+- Gist embeds: `@[gist](https://gist.github.com/...)`.
+- Math: `$$` blocks or inline `$...$`.
+- Footnotes: `[^1]`.
+- Markdown tables are allowed.
+
+## Avoid
+
+- Qiita `:::note info`, `:::note warn`, `:::note alert`.
+- Qiita `diff_language` fences such as `diff_ruby`.
+- HTML `<details>` for collapsible blocks.

--- a/internal/application/draft/prompt.go
+++ b/internal/application/draft/prompt.go
@@ -3,17 +3,43 @@ package draft
 import (
 	"fmt"
 	"strings"
+
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 const maxGuideRunes = 3000
 
 // BuildPrompt creates the concise local-LLM instruction from the style guide and brief only.
 func BuildPrompt(guide WritingStyleGuide, brief ArticleBrief) string {
+	persona, _ := personadomain.DefaultRegistry().Get(brief.PersonaID)
+	format, ok := outputformat.DefaultRegistry().Get(brief.OutputFormatID)
+	if !ok {
+		format = outputformat.DefaultRegistry().MustGet(outputformat.IDNoteArticle)
+	}
+	return BuildPromptForMode(guide, brief, persona, format)
+}
+
+// BuildPromptForMode creates a persona- and format-aware local-LLM instruction.
+func BuildPromptForMode(guide WritingStyleGuide, brief ArticleBrief, persona personadomain.Persona, format outputformat.OutputFormat) string {
 	var prompt strings.Builder
 
-	prompt.WriteString("あなたはNoteにそのまま貼り付けられる日本語Markdown記事を書く編集者です。\n")
+	prompt.WriteString("あなたは指定された人格と媒体に合わせて日本語の下書きを作る編集者です。\n")
 	prompt.WriteString("参考記事本文は与えられていません。文体ガイドと記事ブリーフだけを根拠に、新しい記事を書いてください。\n")
-	prompt.WriteString("出力はMarkdown本文のみ。前置き、解説、内部メモ、コードフェンスは出力しないでください。\n\n")
+	prompt.WriteString("前置き、解説、内部メモは出力しないでください。\n\n")
+
+	prompt.WriteString("## 書き分けモード\n")
+	appendLine(&prompt, "Persona", persona.ID+" / "+persona.DisplayName)
+	appendLine(&prompt, "OutputFormat", format.ID+" / "+format.DisplayName)
+	appendLine(&prompt, "媒体ルール", format.PromptFragment)
+	appendLine(&prompt, "人格メモ", persona.PromptHint())
+	prompt.WriteString("\n")
+
+	if guideMarkdown := formatGuideMarkdown(format.ID); guideMarkdown != "" {
+		prompt.WriteString("## 媒体別Markdownガイド\n")
+		prompt.WriteString(guideMarkdown)
+		prompt.WriteString("\n\n")
+	}
 
 	prompt.WriteString("## 文体ガイド\n")
 	prompt.WriteString(truncateRunes(formatStyleGuide(guide), maxGuideRunes))
@@ -36,19 +62,62 @@ func BuildPrompt(guide WritingStyleGuide, brief ArticleBrief) string {
 	appendDeepDives(&prompt, brief.DeepDives)
 
 	prompt.WriteString("\n## 出力条件\n")
-	prompt.WriteString("1. 1行目は必ず `# タイトル` 形式にする。\n")
-	prompt.WriteString("2. `##` 見出しを使い、導入、本論、結論が自然につながる構成にする。\n")
-	prompt.WriteString("3. 文体ガイドの語り口、段落の長さ、内省と具体例の配分を再現する。\n")
-	prompt.WriteString("4. ブリーフの必須要素を本文に自然に入れ、除外事項は扱わない。\n")
-	prompt.WriteString("5. 文体ガイドの頻出テーマは、無理な羅列にせず、著者の背景や比喩として自然に4語以上回収する。\n")
-	prompt.WriteString("6. 一人称は指定に従うが、全文で6〜8回程度に抑える。主語を省略できる文では省略し、各段落の冒頭を一人称で始めない。\n")
-	prompt.WriteString("7. 鉤括弧の内省や印象的な言葉を4〜6箇所ほど入れ、違和感や気づきを残す。\n")
-	prompt.WriteString("8. 各段落は短すぎる断片にせず、体験、解釈、読者への接続をできるだけ一段落内で結ぶ。\n")
-	prompt.WriteString("9. 最後は読者に残す判断基準か次の一歩で締める。\n")
-	prompt.WriteString("10. 指定された目標文字数に近づける。3000字指定の場合は最低2800字を目安に、短い要約で終わらせず、各見出しで十分に展開する。\n")
-	prompt.WriteString("11. Markdown本文だけを返し、コードフェンスで囲まない。\n")
+	appendOutputConditions(&prompt, format.ID)
 
 	return prompt.String()
+}
+
+func appendOutputConditions(prompt *strings.Builder, formatID string) {
+	common := []string{
+		"媒体ルールを最優先し、指定された形式以外を混ぜない。",
+		"見出しを使い、導入、本論、結論が自然につながる構成にする。",
+		"文体ガイドの語り口、段落の長さ、具体例の配分を再現する。",
+		"ブリーフの必須要素を本文に自然に入れ、除外事項は扱わない。",
+		"指定された目標文字数に近づける。短い要約で終わらせず、各見出しで十分に展開する。",
+		"出力全体をコードフェンスで囲まない。",
+	}
+	formatSpecific := map[string][]string{
+		outputformat.IDNoteArticle: {
+			"noteで変換されやすい最小記法だけを使う。##、###、>、-、1.、**太字**、~~取り消し線~~、---、通常のコードブロックまでに抑える。",
+			"表、脚注、数式、HTML、Zenn/Qiita独自の補足ブロック、ファイル名付きコードフェンスは使わない。",
+			"文体ガイドの頻出テーマは、無理な羅列にせず、著者の背景や比喩として自然に4語以上回収する。",
+			"一人称は指定に従うが、全文で6〜8回程度に抑える。主語を省略できる文では省略し、各段落の冒頭を一人称で始めない。",
+			"鉤括弧の内省や印象的な言葉を4〜6箇所ほど入れ、違和感や気づきを残す。",
+			"各段落は短すぎる断片にせず、体験、解釈、読者への接続をできるだけ一段落内で結ぶ。",
+			"最後は読者に残す判断基準か次の一歩で締める。",
+		},
+		outputformat.IDMarkdownBlog: {
+			"frontmatterのcategoryは ai / engineering / founder / lab のいずれかを選び、langは必ず ja にする。",
+			"会社の技術的知見、実装判断、検証結果、社員へのビジョン共有のいずれに資する記事かが本文から分かるようにする。",
+			"敬語より断定口調を優先し、「実装する」「分かった」「重要だ」のように端的に書く。",
+			"コードフェンスを使う場合は必ず言語名を付け、読者が再現できる前提条件と確認結果を書く。",
+			"最後は会社として次にどう活かすか、または読者が業務でどう判断すべきかで締める。",
+		},
+		outputformat.IDZennArticle: {
+			"技術的前提、手順、コード、失敗しやすい点、参考リンクを分け、読者が再現できる構成にする。",
+			"topicsは5個以内の短い技術タグにする。",
+			"コードブロックは言語名、必要なら `言語:ファイル名`、差分なら `diff 言語` を使う。",
+			"補足は :::message、注意は :::message alert、折りたたみは :::details、リンクカードは @[card](URL) を使う。",
+			"Qiitaの :::note、diff_language、HTML details を混ぜない。",
+			"キャラクター口調は入れすぎず、技術説明の明快さを優先する。",
+		},
+		outputformat.IDQiitaArticle: {
+			"環境、手順、コード、実行結果、トラブルシュートを明確にし、読者がすぐ試せる粒度にする。",
+			"tagsはQiitaで検索されやすい技術名を中心にする。",
+			"コードブロックは言語名、必要なら `言語:ファイル名`、差分なら `diff_言語` を使う。",
+			"補足・警告は :::note info / :::note warn / :::note alert、折りたたみは <details><summary>...</summary>...</details> を使う。",
+			"数式は ```math ブロック、インライン数式は $`...`$ を優先し、Zennの :::message や :::details を混ぜない。",
+		},
+		outputformat.IDHomepageSection: {
+			"MarkdownではなくHTMLだけを出力し、会社サイトでそのまま埋め込める密度にする。",
+			"本文は機能説明だけでなく、読者が問い合わせや相談に進む理由を含める。",
+		},
+	}
+	lines := append([]string{}, common...)
+	lines = append(lines, formatSpecific[formatID]...)
+	for i, line := range lines {
+		prompt.WriteString(fmt.Sprintf("%d. %s\n", i+1, line))
+	}
 }
 
 func formatStyleGuide(guide WritingStyleGuide) string {
@@ -133,7 +202,7 @@ func explicitFirstPersonOverride(brief ArticleBrief) string {
 	if !strings.Contains(text, "一人称") {
 		return ""
 	}
-	for _, candidate := range []string{"僕", "私", "俺", "自分"} {
+	for _, candidate := range []string{"僕", "私", "俺", "自分", "クラウディア", "うち"} {
 		if strings.Contains(text, candidate) {
 			return candidate
 		}

--- a/internal/application/draft/service.go
+++ b/internal/application/draft/service.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 // TextGenerator generates a draft from a prompt.
@@ -33,12 +35,25 @@ func (s *Service) Generate(ctx context.Context, req GenerateRequest) (GenerateRe
 		return GenerateResult{}, err
 	}
 
-	prompt := BuildPrompt(req.StyleGuide, req.Brief)
+	persona := req.Persona
+	if persona.ID == "" {
+		persona, _ = personadomain.DefaultRegistry().Get(req.Brief.PersonaID)
+	}
+	format := req.OutputFormat
+	if format.ID == "" {
+		var ok bool
+		format, ok = outputformat.DefaultRegistry().Get(req.Brief.OutputFormatID)
+		if !ok {
+			format, _ = outputformat.DefaultRegistry().Get(outputformat.IDNoteArticle)
+		}
+	}
+
+	prompt := BuildPromptForMode(req.StyleGuide, req.Brief, persona, format)
 	rawDraft, err := s.generator.Generate(ctx, prompt)
 	if err != nil {
 		return GenerateResult{}, fmt.Errorf("generate draft with local llm: %w", err)
 	}
-	articleDraft, err := articledomain.NewDraft(rawDraft)
+	articleDraft, err := articledomain.NewDraftForFormat(rawDraft, format.ID)
 	if err != nil {
 		return GenerateResult{}, fmt.Errorf("local llm returned an unusable draft: %w", err)
 	}

--- a/internal/application/draft/service_test.go
+++ b/internal/application/draft/service_test.go
@@ -8,6 +8,8 @@ import (
 
 	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
 	authordomain "github.com/teradakousuke/note_maker/internal/domain/author"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 func TestGenerateBuildsPromptFromGuideAndBriefOnly(t *testing.T) {
@@ -74,6 +76,119 @@ func TestGenerateReturnsFailedEvaluationWithoutError(t *testing.T) {
 	}
 	if len(result.Evaluation.Failures) == 0 {
 		t.Fatalf("expected evaluation failures: %#v", result.Evaluation)
+	}
+}
+
+func TestGenerateUsesPersonaAndOutputFormat(t *testing.T) {
+	zennDraft := "---\ntitle: \"Goで検証する\"\nemoji: \"🧪\"\ntype: \"tech\"\ntopics: [\"go\", \"test\"]\npublished: false\n---\n\n## 実装\n\n```go\nfmt.Println(\"ok\")\n```"
+	generator := &fakeGenerator{draft: zennDraft}
+	profile, styleGuide := profileAndGuideFromDraft(t, matchingDraft())
+	persona, _ := personadomain.DefaultRegistry().Get(personadomain.IDCloudia)
+	format, _ := outputformat.DefaultRegistry().Get(outputformat.IDZennArticle)
+
+	result, err := NewService(generator).Generate(context.Background(), GenerateRequest{
+		StyleGuide: styleGuide,
+		Brief: ArticleBrief{
+			StyleProfileID: profile.ID,
+			PersonaID:      persona.ID,
+			OutputFormatID: format.ID,
+			Theme:          "Goで検証する",
+		},
+		AuthorProfile: profile,
+		Persona:       persona,
+		OutputFormat:  format,
+	})
+	if err != nil {
+		t.Fatalf("generate zenn draft: %v", err)
+	}
+	if result.Draft.Markdown() != zennDraft {
+		t.Fatalf("unexpected zenn draft:\n%s", result.Draft.Markdown())
+	}
+	for _, want := range []string{"宇宙野クラウディア", "Zenn記事", "title, emoji, type, topics, published", "## 媒体別Markdownガイド", ":::message", "@[card](https://example.com)"} {
+		if !strings.Contains(generator.prompt, want) {
+			t.Fatalf("prompt does not contain %q:\n%s", want, generator.prompt)
+		}
+	}
+}
+
+func TestPromptIncludesFormatGuideForEveryRegisteredFormat(t *testing.T) {
+	profile, styleGuide := profileAndGuideFromDraft(t, matchingDraft())
+	persona, _ := personadomain.DefaultRegistry().Get(personadomain.IDTerisuke)
+
+	tests := []struct {
+		formatID string
+		want     string
+	}{
+		{outputformat.IDNoteArticle, "Use this guide only for `note_article` output."},
+		{outputformat.IDMarkdownBlog, "corsweb2024/src/content/blog/ja/{slug}.md"},
+		{outputformat.IDZennArticle, "Use this guide only for `zenn_article` output."},
+		{outputformat.IDQiitaArticle, "Use this guide only for `qiita_article` output."},
+		{outputformat.IDHomepageSection, "Return HTML only. Do not output Markdown."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.formatID, func(t *testing.T) {
+			format, ok := outputformat.DefaultRegistry().Get(tt.formatID)
+			if !ok {
+				t.Fatalf("missing format %s", tt.formatID)
+			}
+			prompt := BuildPromptForMode(styleGuide, ArticleBrief{
+				StyleProfileID: profile.ID,
+				PersonaID:      persona.ID,
+				OutputFormatID: tt.formatID,
+				Theme:          "形式別ガイド",
+			}, persona, format)
+			for _, want := range []string{"## 媒体別Markdownガイド", tt.want} {
+				if !strings.Contains(prompt, want) {
+					t.Fatalf("prompt does not contain %q:\n%s", want, prompt)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateUsesCorBlogOutputRules(t *testing.T) {
+	companyBlogDraft := "---\n" +
+		"title: \"AI開発の知見\"\n" +
+		"description: \"AI駆動開発で得た実装判断と検証結果を共有する\"\n" +
+		"pubDate: 2026-05-02\n" +
+		"author: \"Terisuke\"\n" +
+		"category: \"engineering\"\n" +
+		"tags: [\"AI\", \"開発\", \"検証\"]\n" +
+		"lang: \"ja\"\n" +
+		"featured: false\n" +
+		"isDraft: true\n" +
+		"---\n\n" +
+		"# AI開発の知見\n\n" +
+		"会社の実装判断を共有する記事だ。\n\n" +
+		"```go\nfmt.Println(\"ok\")\n```"
+	generator := &fakeGenerator{draft: companyBlogDraft}
+	profile, styleGuide := profileAndGuideFromDraft(t, matchingDraft())
+	persona, _ := personadomain.DefaultRegistry().Get(personadomain.IDTerisuke)
+	format, _ := outputformat.DefaultRegistry().Get(outputformat.IDMarkdownBlog)
+
+	result, err := NewService(generator).Generate(context.Background(), GenerateRequest{
+		StyleGuide: styleGuide,
+		Brief: ArticleBrief{
+			StyleProfileID: profile.ID,
+			PersonaID:      persona.ID,
+			OutputFormatID: format.ID,
+			Theme:          "AI開発の知見",
+		},
+		AuthorProfile: profile,
+		Persona:       persona,
+		OutputFormat:  format,
+	})
+	if err != nil {
+		t.Fatalf("generate company blog draft: %v", err)
+	}
+	if result.Draft.Markdown() != companyBlogDraft {
+		t.Fatalf("unexpected company blog draft:\n%s", result.Draft.Markdown())
+	}
+	for _, want := range []string{"corsweb2024", "category は ai / engineering / founder / lab", "langは必ず ja", "社員へのビジョン共有"} {
+		if !strings.Contains(generator.prompt, want) {
+			t.Fatalf("prompt does not contain %q:\n%s", want, generator.prompt)
+		}
 	}
 }
 

--- a/internal/application/draft/types.go
+++ b/internal/application/draft/types.go
@@ -4,6 +4,8 @@ import (
 	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
 	authordomain "github.com/teradakousuke/note_maker/internal/domain/author"
 	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 // WritingStyleGuide is the compact author style guide used for draft generation.
@@ -23,6 +25,8 @@ type GenerateRequest struct {
 	StyleGuide    WritingStyleGuide
 	Brief         ArticleBrief
 	AuthorProfile AuthorStyleProfile
+	Persona       personadomain.Persona
+	OutputFormat  outputformat.OutputFormat
 }
 
 // GenerateResult returns the validated draft and its strict style evaluation.

--- a/internal/domain/article/draft.go
+++ b/internal/domain/article/draft.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
 )
 
 var (
@@ -16,17 +18,23 @@ type Draft struct {
 	markdown string
 }
 
-// NewDraft normalizes and validates generated Markdown.
+// NewDraft normalizes and validates generated Markdown for note_article.
 func NewDraft(raw string) (Draft, error) {
+	return NewDraftForFormat(raw, outputformat.IDNoteArticle)
+}
+
+// NewDraftForFormat normalizes and validates generated output for a publishing target.
+func NewDraftForFormat(raw, formatID string) (Draft, error) {
 	markdown := normalizeDraft(raw)
 	if markdown == "" {
 		return Draft{}, fmt.Errorf("draft is empty")
 	}
-	if !strings.HasPrefix(markdown, "# ") {
-		return Draft{}, fmt.Errorf("draft must start with a level-1 Markdown title")
+	format, ok := outputformat.DefaultRegistry().Get(formatID)
+	if !ok {
+		return Draft{}, fmt.Errorf("unknown output format %q", formatID)
 	}
-	if strings.Contains(markdown, "```") {
-		return Draft{}, fmt.Errorf("draft must not wrap the article in code fences")
+	if err := format.Validator.Validate(markdown); err != nil {
+		return Draft{}, err
 	}
 	if strings.Contains(markdown, "以下") && strings.Contains(markdown, "下書き") && strings.Index(markdown, "# ") > 20 {
 		return Draft{}, fmt.Errorf("draft appears to contain preamble before the article")
@@ -49,13 +57,17 @@ func normalizeDraft(raw string) string {
 	if match := codeFencePattern.FindStringSubmatch(text); len(match) == 2 {
 		text = strings.TrimSpace(match[1])
 	}
+	droppedPreambleWithFence := false
 	if idx := strings.Index(text, "# "); idx > 0 {
 		preamble := strings.TrimSpace(text[:idx])
 		if looksLikePreamble(preamble) && canDropPreamble(preamble) {
+			droppedPreambleWithFence = strings.Contains(preamble, "```")
 			text = strings.TrimSpace(text[idx:])
 		}
 	}
-	text = strings.TrimSuffix(text, "```")
+	if droppedPreambleWithFence {
+		text = strings.TrimSuffix(text, "```")
+	}
 	text = strings.TrimSpace(text)
 	lines := strings.Split(text, "\n")
 	cleaned := make([]string, 0, len(lines))

--- a/internal/domain/article/draft_test.go
+++ b/internal/domain/article/draft_test.go
@@ -14,6 +14,22 @@ func TestNewDraftNormalizesPasteReadyMarkdown(t *testing.T) {
 	}
 }
 
+func TestNewDraftForFormatAllowsTechnicalFormats(t *testing.T) {
+	zenn := "---\ntitle: \"Goで試す\"\nemoji: \"🧪\"\ntype: \"tech\"\ntopics: [\"go\", \"test\"]\npublished: false\n---\n\n## 実装\n\n```go\nfmt.Println(\"ok\")\n```"
+	draft, err := NewDraftForFormat(zenn, "zenn_article")
+	if err != nil {
+		t.Fatalf("zenn draft: %v", err)
+	}
+	if draft.Markdown() != zenn {
+		t.Fatalf("unexpected draft:\n%s", draft.Markdown())
+	}
+
+	homepage := "<section><h2>AI活用</h2><p>小さく試せる導入文です。</p></section>"
+	if _, err := NewDraftForFormat(homepage, "homepage_section"); err != nil {
+		t.Fatalf("homepage draft: %v", err)
+	}
+}
+
 func TestNewDraftRejectsNonArticleOutput(t *testing.T) {
 	if _, err := NewDraft("承知しました。記事を書きます。"); err == nil {
 		t.Fatal("expected validation error")

--- a/internal/domain/brief/session.go
+++ b/internal/domain/brief/session.go
@@ -303,6 +303,8 @@ func (s ArticleBriefSession) AssembleBrief() ArticleBrief {
 	}
 	return ArticleBrief{
 		StyleProfileID:        s.StyleProfileID,
+		PersonaID:             s.PersonaID,
+		OutputFormatID:        s.OutputFormatID,
 		Theme:                 get(QuestionIDTheme),
 		OpeningEpisode:        get(QuestionIDOpeningEpisode),
 		Reader:                get(QuestionIDReader),

--- a/internal/domain/brief/types.go
+++ b/internal/domain/brief/types.go
@@ -3,6 +3,9 @@ package brief
 import (
 	"fmt"
 	"strings"
+
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	"github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 const (
@@ -64,6 +67,8 @@ type BriefAnswer struct {
 // ArticleBrief is the structured requirement set assembled from a completed interview.
 type ArticleBrief struct {
 	StyleProfileID        string
+	PersonaID             string
+	OutputFormatID        string
 	Theme                 string
 	OpeningEpisode        string
 	Reader                string
@@ -81,6 +86,9 @@ type ArticleBrief struct {
 type ArticleBriefSession struct {
 	ID              string
 	StyleProfileID  string
+	PersonaID       string
+	OutputFormatID  string
+	ParentSessionID string
 	Phase           InterviewPhase
 	Questions       []ArticleQuestion
 	Answers         []BriefAnswer
@@ -95,6 +103,11 @@ func NewArticleBriefSession(id, styleProfileID string) (ArticleBriefSession, err
 
 // NewArticleBriefSessionWithQuestions creates a session with a caller-provided question set.
 func NewArticleBriefSessionWithQuestions(id, styleProfileID string, questions []ArticleQuestion) (ArticleBriefSession, error) {
+	return NewArticleBriefSessionWithOptions(id, styleProfileID, persona.IDTerisuke, outputformat.IDNoteArticle, "", questions)
+}
+
+// NewArticleBriefSessionWithOptions creates a session with persona/format metadata.
+func NewArticleBriefSessionWithOptions(id, styleProfileID, personaID, outputFormatID, parentSessionID string, questions []ArticleQuestion) (ArticleBriefSession, error) {
 	if strings.TrimSpace(id) == "" {
 		return ArticleBriefSession{}, fmt.Errorf("session id is required")
 	}
@@ -106,10 +119,13 @@ func NewArticleBriefSessionWithQuestions(id, styleProfileID string, questions []
 		return ArticleBriefSession{}, fmt.Errorf("questions are required")
 	}
 	return ArticleBriefSession{
-		ID:             strings.TrimSpace(id),
-		StyleProfileID: strings.TrimSpace(styleProfileID),
-		Phase:          InterviewPhaseFixedQuestions,
-		Questions:      questions,
+		ID:              strings.TrimSpace(id),
+		StyleProfileID:  strings.TrimSpace(styleProfileID),
+		PersonaID:       persona.NormalizeID(personaID),
+		OutputFormatID:  outputformat.NormalizeID(outputFormatID),
+		ParentSessionID: strings.TrimSpace(parentSessionID),
+		Phase:           InterviewPhaseFixedQuestions,
+		Questions:       questions,
 	}, nil
 }
 

--- a/internal/domain/format/format.go
+++ b/internal/domain/format/format.go
@@ -1,0 +1,333 @@
+package format
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	IDNoteArticle     = "note_article"
+	IDMarkdownBlog    = "markdown_blog"
+	IDZennArticle     = "zenn_article"
+	IDQiitaArticle    = "qiita_article"
+	IDHomepageSection = "homepage_section"
+)
+
+// Validator checks whether generated output fits a publishing target.
+type Validator interface {
+	Validate(markdown string) error
+}
+
+// OutputFormat describes one target writing surface.
+type OutputFormat struct {
+	ID             string    `json:"id"`
+	DisplayName    string    `json:"display_name"`
+	Description    string    `json:"description"`
+	PromptFragment string    `json:"prompt_fragment"`
+	Validator      Validator `json:"-"`
+	AllowsCode     bool      `json:"allows_code"`
+	RequiresMeta   bool      `json:"requires_meta"`
+}
+
+// Registry resolves output formats by id.
+type Registry struct {
+	formats map[string]OutputFormat
+	order   []string
+}
+
+// DefaultRegistry returns the built-in format set.
+func DefaultRegistry() Registry {
+	formats := []OutputFormat{
+		{
+			ID:          IDNoteArticle,
+			DisplayName: "note",
+			Description: "note.com向け。貼り付け変換で崩れにくい最小Markdown。frontmatterなし。",
+			PromptFragment: strings.TrimSpace(`note.comにそのまま貼れる日本語Markdown記事として書く。
+1行目は必ず # タイトル。frontmatter、HTML、Zenn/Qiita独自記法は使わない。
+noteエディタで変換されやすい記法だけを使う: ## 大見出し、### 小見出し、> 引用、- 箇条書き、1. 番号付きリスト、**太字**、~~取り消し線~~、--- 区切り線。
+コード例が必要な場合だけ通常のコードブロックを使う。ファイル名付きコードフェンス、diff指定、メッセージブロック、脚注、数式、表は避ける。
+面白い技術的な試み、考え方、体験からの気づきを、広い読者を引き寄せる読み物としてまとめる。
+体験、違和感、解釈、読者への提案を自然につなぐ。`),
+			Validator:  NoteValidator{},
+			AllowsCode: true,
+		},
+		{
+			ID:          IDMarkdownBlog,
+			DisplayName: "会社ブログ",
+			Description: "cor-jp.com / corsweb2024向け。Astro content blogのfrontmatter必須、日本語記事。",
+			PromptFragment: strings.TrimSpace(`Cor.inc会社ブログ向けの日本語Markdown記事として書く。
+先頭にcorsweb2024のAstro content用YAML frontmatterを必ず置く。必須項目は title, description, pubDate, author, category, tags, lang, featured。
+frontmatter例:
+---
+title: "記事タイトル"
+description: "50-100文字程度の説明"
+pubDate: 2026-05-02
+author: "Terisuke"
+category: "engineering"
+tags: ["AI", "開発", "知見"]
+lang: "ja"
+featured: false
+isDraft: true
+---
+category は ai / engineering / founder / lab のいずれかにする。lang は必ず "ja"。
+本文は # または ## の記事タイトルから始め、60-170行を目安に、断定口調「だ」「である」「する」を基本にする。
+会社ブログでは、自社の技術的知見の報告、実装判断、検証結果、または社員へのビジョン共有を主目的にする。
+コードフェンスには必ず言語名を付ける。背景、構成、課題、解決、実測データ、学び、次の行動を明確にする。`),
+			Validator:    MarkdownBlogValidator{},
+			AllowsCode:   true,
+			RequiresMeta: true,
+		},
+		{
+			ID:          IDZennArticle,
+			DisplayName: "Zenn",
+			Description: "Zenn向け。YAML frontmatter必須、tech/idea、topics、publishedを含める。",
+			PromptFragment: strings.TrimSpace(`Zenn記事として書く。
+先頭にYAML frontmatterを置き、title, emoji, type, topics, published を必ず含める。
+type は tech または idea。topics は5個以内。
+本文の見出しは ## から始める。コードブロックは「ts:src/main.ts」のように言語名と必要ならファイル名を使う。差分は「diff ts」のように書く。
+補足はZenn独自の :::message、注意は :::message alert、折りたたみは :::details を使う。リンクカードや外部埋め込みは @[card](URL) などZenn形式を使う。
+数式は $$ ブロックまたは $...$、脚注は [^1]、表はMarkdownテーブルを使える。Qiitaの :::note は使わない。
+本文では技術的な前提、手順、コード例、つまずきやすい点を明確にする。`),
+			Validator:    ZennValidator{},
+			AllowsCode:   true,
+			RequiresMeta: true,
+		},
+		{
+			ID:          IDQiitaArticle,
+			DisplayName: "Qiita",
+			Description: "Qiita向け。title/tagsのfrontmatter、コード例、手順重視。",
+			PromptFragment: strings.TrimSpace(`Qiita記事として書く。
+先頭にYAML frontmatterを置き、title と tags を必ず含める。
+本文は再現手順、環境、コード例、結果、参考リンクを重視する。読者がすぐ試せる粒度にする。
+コードブロックは「rb:app.rb」のように言語名と必要ならファイル名を使う。差分はQiita形式の「diff_ruby」のように書く。
+補足・警告はQiitaの :::note info / :::note warn / :::note alert を使う。折りたたみはHTMLの <details><summary>...</summary>...</details> を使い、Zennの :::details は使わない。
+数式は math コードブロック、インライン数式はQiitaのバッククォート付きドル記法を優先する。表はMarkdownテーブルまたは必要時だけHTML tableを使う。`),
+			Validator:    QiitaValidator{},
+			AllowsCode:   true,
+			RequiresMeta: true,
+		},
+		{
+			ID:          IDHomepageSection,
+			DisplayName: "ホームページHTML",
+			Description: "Webページ埋め込み向け。HTML section、h2、p、CTAを出力。",
+			PromptFragment: strings.TrimSpace(`Webサイトに埋め込むHTMLセクションとして書く。
+MarkdownではなくHTMLだけを返す。少なくとも <section>, <h2>, <p> を含める。
+必要に応じてCTAの <a> を入れ、会社サイトの落ち着いた説明文として使える密度にする。`),
+			Validator: HomepageSectionValidator{},
+		},
+	}
+	registry := Registry{formats: make(map[string]OutputFormat, len(formats)), order: make([]string, 0, len(formats))}
+	for _, item := range formats {
+		registry.formats[item.ID] = item
+		registry.order = append(registry.order, item.ID)
+	}
+	return registry
+}
+
+// List returns registered formats in stable UI order.
+func (r Registry) List() []OutputFormat {
+	result := make([]OutputFormat, 0, len(r.order))
+	for _, id := range r.order {
+		if format, ok := r.formats[id]; ok {
+			result = append(result, format)
+		}
+	}
+	return result
+}
+
+// Get returns a format, defaulting empty ids to note_article.
+func (r Registry) Get(id string) (OutputFormat, bool) {
+	id = NormalizeID(id)
+	format, ok := r.formats[id]
+	return format, ok
+}
+
+// MustGet returns a format or panics. Use only for package defaults/tests.
+func (r Registry) MustGet(id string) OutputFormat {
+	format, ok := r.Get(id)
+	if !ok {
+		panic("unknown output format: " + id)
+	}
+	return format
+}
+
+// NormalizeID returns the default format when id is empty.
+func NormalizeID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return IDNoteArticle
+	}
+	return id
+}
+
+type NoteValidator struct{}
+
+func (NoteValidator) Validate(markdown string) error {
+	markdown = strings.TrimSpace(markdown)
+	if !strings.HasPrefix(markdown, "# ") {
+		return fmt.Errorf("note article must start with a level-1 Markdown title")
+	}
+	if hasFrontMatter(markdown) {
+		return fmt.Errorf("note article must not contain frontmatter")
+	}
+	if containsAny(markdown, []string{":::message", ":::note", ":::details", "@[card]", "@[gist]", "$$", "<details", "<table"}) {
+		return fmt.Errorf("note article must not contain platform-specific extended Markdown")
+	}
+	if regexp.MustCompile("(?m)^```\\S+[:_]").MatchString(markdown) {
+		return fmt.Errorf("note article must not contain filename or diff-specific code fences")
+	}
+	return nil
+}
+
+type MarkdownBlogValidator struct{}
+
+func (MarkdownBlogValidator) Validate(markdown string) error {
+	markdown = strings.TrimSpace(markdown)
+	if !hasFrontMatter(markdown) {
+		return fmt.Errorf("company blog article requires YAML frontmatter")
+	}
+	frontmatter := frontMatter(markdown)
+	requiredKeys := []string{"title:", "description:", "pubDate:", "author:", "category:", "tags:", "lang:", "featured:"}
+	for _, key := range requiredKeys {
+		if !strings.Contains(frontmatter, key) {
+			return fmt.Errorf("company blog frontmatter missing %s", strings.TrimSuffix(key, ":"))
+		}
+	}
+	if !regexp.MustCompile(`(?m)^category:\s*"?\b(ai|engineering|founder|lab)\b"?`).MatchString(frontmatter) {
+		return fmt.Errorf("company blog category must be ai, engineering, founder, or lab")
+	}
+	if !regexp.MustCompile(`(?m)^lang:\s*"?ja"?`).MatchString(frontmatter) {
+		return fmt.Errorf("company blog lang must be ja")
+	}
+	if !regexp.MustCompile(`(?m)^tags:\s*\[.+\]`).MatchString(frontmatter) {
+		return fmt.Errorf("company blog tags must be an inline YAML array")
+	}
+	body := bodyAfterFrontMatter(markdown)
+	if !strings.HasPrefix(body, "# ") && !strings.HasPrefix(body, "## ") {
+		return fmt.Errorf("company blog body must start with # title or ## title")
+	}
+	if hasCodeFenceWithoutLanguage(body) {
+		return fmt.Errorf("company blog code fences must specify a language")
+	}
+	return nil
+}
+
+type ZennValidator struct{}
+
+func (ZennValidator) Validate(markdown string) error {
+	if !hasFrontMatter(markdown) {
+		return fmt.Errorf("zenn article requires YAML frontmatter")
+	}
+	frontmatter := frontMatter(markdown)
+	for _, key := range []string{"title:", "emoji:", "type:", "topics:", "published:"} {
+		if !strings.Contains(frontmatter, key) {
+			return fmt.Errorf("zenn frontmatter missing %s", strings.TrimSuffix(key, ":"))
+		}
+	}
+	if !regexp.MustCompile(`(?m)^type:\s*"?\b(tech|idea)\b"?`).MatchString(frontmatter) {
+		return fmt.Errorf("zenn type must be tech or idea")
+	}
+	if strings.Contains(markdown, ":::note") {
+		return fmt.Errorf("zenn article must use :::message, not Qiita :::note")
+	}
+	if strings.Contains(markdown, "```diff_") {
+		return fmt.Errorf("zenn diff code fences use `diff language`, not diff_language")
+	}
+	return nil
+}
+
+type QiitaValidator struct{}
+
+func (QiitaValidator) Validate(markdown string) error {
+	if !hasFrontMatter(markdown) {
+		return fmt.Errorf("qiita article requires YAML frontmatter")
+	}
+	frontmatter := frontMatter(markdown)
+	for _, key := range []string{"title:", "tags:"} {
+		if !strings.Contains(frontmatter, key) {
+			return fmt.Errorf("qiita frontmatter missing %s", strings.TrimSuffix(key, ":"))
+		}
+	}
+	if strings.Contains(markdown, ":::message") || strings.Contains(markdown, ":::details") || strings.Contains(markdown, "@[card]") {
+		return fmt.Errorf("qiita article must not contain Zenn-specific notation")
+	}
+	if regexp.MustCompile("(?m)^```diff\\s+\\w+").MatchString(markdown) {
+		return fmt.Errorf("qiita diff code fences use diff_language, not `diff language`")
+	}
+	return nil
+}
+
+type HomepageSectionValidator struct{}
+
+func (HomepageSectionValidator) Validate(markdown string) error {
+	html := strings.TrimSpace(strings.ToLower(markdown))
+	if strings.HasPrefix(html, "#") {
+		return fmt.Errorf("homepage section must be HTML, not Markdown")
+	}
+	for _, tag := range []string{"<section", "<h2", "<p"} {
+		if !strings.Contains(html, tag) {
+			return fmt.Errorf("homepage section must contain %s", tag)
+		}
+	}
+	return nil
+}
+
+func hasFrontMatter(markdown string) bool {
+	return strings.HasPrefix(strings.TrimSpace(markdown), "---\n")
+}
+
+func frontMatter(markdown string) string {
+	markdown = strings.TrimSpace(markdown)
+	if !strings.HasPrefix(markdown, "---\n") {
+		return ""
+	}
+	rest := strings.TrimPrefix(markdown, "---\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+func bodyAfterFrontMatter(markdown string) string {
+	markdown = strings.TrimSpace(markdown)
+	if !strings.HasPrefix(markdown, "---\n") {
+		return markdown
+	}
+	rest := strings.TrimPrefix(markdown, "---\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[end+len("\n---"):])
+}
+
+func hasCodeFenceWithoutLanguage(markdown string) bool {
+	inFence := false
+	for _, line := range strings.Split(markdown, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "```") {
+			continue
+		}
+		if !inFence {
+			if strings.TrimSpace(strings.TrimPrefix(trimmed, "```")) == "" {
+				return true
+			}
+			inFence = true
+			continue
+		}
+		inFence = false
+	}
+	return false
+}
+
+func containsAny(value string, needles []string) bool {
+	lower := strings.ToLower(value)
+	for _, needle := range needles {
+		if strings.Contains(lower, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domain/format/format_test.go
+++ b/internal/domain/format/format_test.go
@@ -1,0 +1,111 @@
+package format
+
+import "testing"
+
+func TestDefaultRegistryContainsFormats(t *testing.T) {
+	registry := DefaultRegistry()
+	for _, id := range []string{IDNoteArticle, IDMarkdownBlog, IDZennArticle, IDQiitaArticle, IDHomepageSection} {
+		if _, ok := registry.Get(id); !ok {
+			t.Fatalf("missing format %s", id)
+		}
+	}
+}
+
+func TestValidators(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator Validator
+		valid     string
+		invalid   string
+	}{
+		{
+			name:      "note",
+			validator: NoteValidator{},
+			valid:     "# タイトル\n\n## 見出し\n\n本文\n\n```go\nfmt.Println(1)\n```",
+			invalid:   "# タイトル\n\n:::message\nZennの補足\n:::",
+		},
+		{
+			name:      "blog",
+			validator: MarkdownBlogValidator{},
+			valid: "---\n" +
+				"title: \"AI開発の知見\"\n" +
+				"description: \"AI駆動開発で得た実装判断と検証結果を共有する\"\n" +
+				"pubDate: 2026-05-02\n" +
+				"author: \"Terisuke\"\n" +
+				"category: \"engineering\"\n" +
+				"tags: [\"AI\", \"開発\", \"検証\"]\n" +
+				"lang: \"ja\"\n" +
+				"featured: false\n" +
+				"isDraft: true\n" +
+				"---\n\n" +
+				"# AI開発の知見\n\n" +
+				"```go\nfmt.Println(1)\n```",
+			invalid: "## 実装\n\n```go\nfmt.Println(1)\n```",
+		},
+		{
+			name:      "zenn",
+			validator: ZennValidator{},
+			valid:     "---\ntitle: \"T\"\nemoji: \"📝\"\ntype: \"tech\"\ntopics: [\"go\"]\npublished: false\n---\n\n## 本文\n\n:::message\n補足\n:::\n\n```diff go\n+fmt.Println(1)\n```",
+			invalid:   "---\ntitle: T\n---\n本文",
+		},
+		{
+			name:      "qiita",
+			validator: QiitaValidator{},
+			valid:     "---\ntitle: \"T\"\ntags: [{name: Go, versions: [\"1.24\"]}]\n---\n\n## 本文\n\n:::note warn\n注意\n:::\n\n```diff_go\n+fmt.Println(1)\n```",
+			invalid:   "---\ntitle: T\n---\n本文",
+		},
+		{
+			name:      "homepage",
+			validator: HomepageSectionValidator{},
+			valid:     "<section><h2>見出し</h2><p>本文</p></section>",
+			invalid:   "# 見出し\n\n本文",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.validator.Validate(tt.valid); err != nil {
+				t.Fatalf("valid rejected: %v", err)
+			}
+			if err := tt.validator.Validate(tt.invalid); err == nil {
+				t.Fatal("invalid accepted")
+			}
+		})
+	}
+}
+
+func TestPlatformSpecificNotationIsNotMixed(t *testing.T) {
+	zennWithQiitaNote := "---\ntitle: \"T\"\nemoji: \"📝\"\ntype: \"tech\"\ntopics: [\"go\"]\npublished: false\n---\n\n:::note info\nQiita記法\n:::"
+	if err := (ZennValidator{}).Validate(zennWithQiitaNote); err == nil {
+		t.Fatal("expected zenn validator to reject Qiita note notation")
+	}
+
+	qiitaWithZennMessage := "---\ntitle: \"T\"\ntags: [{name: Go}]\n---\n\n:::message\nZenn記法\n:::"
+	if err := (QiitaValidator{}).Validate(qiitaWithZennMessage); err == nil {
+		t.Fatal("expected qiita validator to reject Zenn message notation")
+	}
+
+	noteWithFilenameFence := "# タイトル\n\n```go:main.go\nfmt.Println(1)\n```"
+	if err := (NoteValidator{}).Validate(noteWithFilenameFence); err == nil {
+		t.Fatal("expected note validator to reject filename code fence")
+	}
+}
+
+func TestMarkdownBlogRejectsUnsupportedCorBlogMetadata(t *testing.T) {
+	invalid := `---
+title: "Vision"
+description: "社員向けのビジョン共有"
+pubDate: 2026-05-02
+author: "Terisuke"
+category: "culture"
+tags: ["Vision"]
+lang: "en"
+featured: false
+---
+
+# Vision`
+
+	if err := (MarkdownBlogValidator{}).Validate(invalid); err == nil {
+		t.Fatal("expected invalid company blog metadata to be rejected")
+	}
+}

--- a/internal/domain/persona/persona.go
+++ b/internal/domain/persona/persona.go
@@ -1,0 +1,101 @@
+package persona
+
+import "strings"
+
+const (
+	IDTerisuke = "terisuke"
+	IDCloudia  = "cloudia"
+)
+
+// AuthorSource identifies public material used to derive a persona's style.
+type AuthorSource struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
+	URL  string `json:"url"`
+}
+
+// VoiceNotes are practical prompt hints for one writing identity.
+type VoiceNotes struct {
+	FirstPerson   []string `json:"first_person"`
+	Tone          string   `json:"tone"`
+	TitlePatterns []string `json:"title_patterns"`
+	AntiPatterns  []string `json:"anti_patterns"`
+}
+
+// Persona is a selectable writing identity.
+type Persona struct {
+	ID            string         `json:"id"`
+	DisplayName   string         `json:"display_name"`
+	Description   string         `json:"description"`
+	DefaultFormat string         `json:"default_format"`
+	Sources       []AuthorSource `json:"sources"`
+	VoiceNotes    VoiceNotes     `json:"voice_notes"`
+}
+
+// PromptHint turns voice notes into concise draft-generation guidance.
+func (p Persona) PromptHint() string {
+	var lines []string
+	if p.DisplayName != "" {
+		lines = append(lines, "人格: "+p.DisplayName)
+	}
+	if p.VoiceNotes.Tone != "" {
+		lines = append(lines, "トーン: "+p.VoiceNotes.Tone)
+	}
+	if len(p.VoiceNotes.FirstPerson) > 0 {
+		lines = append(lines, "一人称候補: "+strings.Join(p.VoiceNotes.FirstPerson, " / "))
+	}
+	if len(p.VoiceNotes.TitlePatterns) > 0 {
+		lines = append(lines, "タイトル傾向: "+strings.Join(p.VoiceNotes.TitlePatterns, "、"))
+	}
+	if len(p.VoiceNotes.AntiPatterns) > 0 {
+		lines = append(lines, "避ける混線: "+strings.Join(p.VoiceNotes.AntiPatterns, "、"))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Registry resolves personas by id.
+type Registry struct {
+	personas map[string]Persona
+	order    []string
+}
+
+// DefaultRegistry returns the built-in persona set.
+func DefaultRegistry() Registry {
+	personas := []Persona{
+		Terisuke(),
+		Cloudia(),
+	}
+	registry := Registry{personas: make(map[string]Persona, len(personas)), order: make([]string, 0, len(personas))}
+	for _, item := range personas {
+		registry.personas[item.ID] = item
+		registry.order = append(registry.order, item.ID)
+	}
+	return registry
+}
+
+// List returns personas in stable UI order.
+func (r Registry) List() []Persona {
+	result := make([]Persona, 0, len(r.order))
+	for _, id := range r.order {
+		if item, ok := r.personas[id]; ok {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// Get returns a persona, defaulting empty ids to terisuke.
+func (r Registry) Get(id string) (Persona, bool) {
+	id = NormalizeID(id)
+	item, ok := r.personas[id]
+	return item, ok
+}
+
+// NormalizeID returns the default persona when id is empty.
+func NormalizeID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return IDTerisuke
+	}
+	return id
+}

--- a/internal/domain/persona/persona_test.go
+++ b/internal/domain/persona/persona_test.go
@@ -1,0 +1,27 @@
+package persona
+
+import "testing"
+
+func TestDefaultRegistryContainsSeedPersonas(t *testing.T) {
+	registry := DefaultRegistry()
+	for _, id := range []string{IDTerisuke, IDCloudia} {
+		item, ok := registry.Get(id)
+		if !ok {
+			t.Fatalf("missing persona %s", id)
+		}
+		if item.DefaultFormat == "" || len(item.Sources) == 0 || item.PromptHint() == "" {
+			t.Fatalf("persona is incomplete: %#v", item)
+		}
+	}
+}
+
+func TestPersonasKeepVoicesSeparate(t *testing.T) {
+	terisuke, _ := DefaultRegistry().Get(IDTerisuke)
+	cloudia, _ := DefaultRegistry().Get(IDCloudia)
+	if terisuke.DefaultFormat == cloudia.DefaultFormat {
+		t.Fatal("seed personas should default to different formats")
+	}
+	if terisuke.PromptHint() == cloudia.PromptHint() {
+		t.Fatal("seed personas should have distinct prompt hints")
+	}
+}

--- a/internal/domain/persona/seed.go
+++ b/internal/domain/persona/seed.go
@@ -1,0 +1,44 @@
+package persona
+
+import outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+
+// Terisuke returns the owner's reflective entrepreneur/engineer persona.
+func Terisuke() Persona {
+	return Persona{
+		ID:            IDTerisuke,
+		DisplayName:   "てりすけ",
+		Description:   "本人名義。noteでは広い読者向けの技術的な試みや考え、会社ブログでは技術知見とビジョン共有を書く。",
+		DefaultFormat: outputformat.IDNoteArticle,
+		Sources: []AuthorSource{
+			{Kind: "note", Ref: "cor_instrument", URL: "https://note.com/cor_instrument/rss"},
+			{Kind: "rss", Ref: "cor-jp-blog", URL: "https://cor-jp.com/rss.xml"},
+			{Kind: "github", Ref: "corsweb2024-blog", URL: "https://github.com/Cor-Incorporated/corsweb2024/tree/main/src/content/blog/ja"},
+		},
+		VoiceNotes: VoiceNotes{
+			FirstPerson:   []string{"僕", "私"},
+			Tone:          "noteは内省的に実体験から違和感を出発点にし、技術や起業の話を人生の判断基準へ接続する。会社ブログは断定口調で、実装判断、検証結果、社員へのビジョン共有を具体的に書く。",
+			TitlePatterns: []string{"〜した話", "〜してしまった件", "なぜ〜なのか", "【実体験】"},
+			AntiPatterns:  []string{"クラウディア風の博多弁", "感嘆符の連打", "キャラクター口調"},
+		},
+	}
+}
+
+// Cloudia returns the character-branded technical explainer persona.
+func Cloudia() Persona {
+	return Persona{
+		ID:            IDCloudia,
+		DisplayName:   "宇宙野クラウディア",
+		Description:   "架空キャラクター名義。AI・JavaScript・Pythonを明るく博多弁混じりで解説する。",
+		DefaultFormat: outputformat.IDZennArticle,
+		Sources: []AuthorSource{
+			{Kind: "zenn", Ref: "cloudia", URL: "https://zenn.dev/cloudia/feed?all=1"},
+			{Kind: "qiita", Ref: "Cloudia_Cor_Inc", URL: "https://qiita.com/api/v2/users/Cloudia_Cor_Inc/items"},
+		},
+		VoiceNotes: VoiceNotes{
+			FirstPerson:   []string{"クラウディア", "うち"},
+			Tone:          "明るい技術解説。博多弁を少し混ぜ、初心者にも親しみやすく、手順とコードを楽しく案内する。",
+			TitlePatterns: []string{"クラウディア流！", "AI探検記【前編】", "〜を探せ！", "なんしよっと？"},
+			AntiPatterns:  []string{"てりすけ風の重い内省", "経営エッセイ調", "断定的な人生論"},
+		},
+	}
+}

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -15,7 +15,11 @@ import (
 	authorstyleapp "github.com/teradakousuke/note_maker/internal/application/authorstyle"
 	briefapp "github.com/teradakousuke/note_maker/internal/application/brief"
 	draftapp "github.com/teradakousuke/note_maker/internal/application/draft"
+	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
+	authordomain "github.com/teradakousuke/note_maker/internal/domain/author"
 	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 	"github.com/teradakousuke/note_maker/internal/infrastructure/llamacpp"
 	notenote "github.com/teradakousuke/note_maker/internal/infrastructure/note"
 	"github.com/teradakousuke/note_maker/internal/infrastructure/repository/memory"
@@ -42,6 +46,10 @@ type analyzeAuthorStyleRequest struct {
 	StyleModel  string   `json:"style_model"`
 }
 
+type seedAuthorStyleRequest struct {
+	PersonaID string `json:"persona_id"`
+}
+
 type authorStyleResponse struct {
 	ID            string `json:"id"`
 	ProfileID     string `json:"profile_id"`
@@ -56,6 +64,8 @@ type authorStyleResponse struct {
 type createBriefSessionRequest struct {
 	StyleProfileID string                `json:"style_profile_id"`
 	SessionID      string                `json:"session_id"`
+	PersonaID      string                `json:"persona_id"`
+	OutputFormatID string                `json:"output_format_id"`
 	BriefModel     string                `json:"brief_model"`
 	Questions      []articleQuestionJSON `json:"questions"`
 }
@@ -67,13 +77,16 @@ type answerBriefSessionRequest struct {
 }
 
 type briefSessionResponse struct {
-	SessionID      string                    `json:"session_id"`
-	StyleProfileID string                    `json:"style_profile_id"`
-	Phase          string                    `json:"phase"`
-	Completed      bool                      `json:"completed"`
-	NextQuestion   *articleQuestionJSON      `json:"next_question,omitempty"`
-	Brief          *briefdomain.ArticleBrief `json:"brief,omitempty"`
-	Answers        []briefdomain.BriefAnswer `json:"answers"`
+	SessionID       string                    `json:"session_id"`
+	StyleProfileID  string                    `json:"style_profile_id"`
+	PersonaID       string                    `json:"persona_id"`
+	OutputFormatID  string                    `json:"output_format_id"`
+	ParentSessionID string                    `json:"parent_session_id,omitempty"`
+	Phase           string                    `json:"phase"`
+	Completed       bool                      `json:"completed"`
+	NextQuestion    *articleQuestionJSON      `json:"next_question,omitempty"`
+	Brief           *briefdomain.ArticleBrief `json:"brief,omitempty"`
+	Answers         []briefdomain.BriefAnswer `json:"answers"`
 }
 
 type articleQuestionJSON struct {
@@ -88,12 +101,48 @@ type articleQuestionJSON struct {
 type generateDraftRequest struct {
 	StyleProfileID string `json:"style_profile_id"`
 	SessionID      string `json:"session_id"`
+	PersonaID      string `json:"persona_id"`
+	OutputFormatID string `json:"output_format_id"`
 	DraftModel     string `json:"draft_model"`
 }
 
 type generateDraftResponse struct {
 	Draft      string                   `json:"draft"`
 	Evaluation draftapp.StyleEvaluation `json:"evaluation"`
+}
+
+// ListPersonasHandler returns built-in writing personas.
+func ListPersonasHandler(w http.ResponseWriter, r *http.Request) {
+	respondWithJSON(w, http.StatusOK, personadomain.DefaultRegistry().List())
+}
+
+// ListFormatsHandler returns built-in output formats.
+func ListFormatsHandler(w http.ResponseWriter, r *http.Request) {
+	respondWithJSON(w, http.StatusOK, outputformat.DefaultRegistry().List())
+}
+
+// SeedAuthorStyleHandler stores a practical persona preset as a style guide.
+func SeedAuthorStyleHandler(w http.ResponseWriter, r *http.Request) {
+	var req seedAuthorStyleRequest
+	if err := decodeJSONRequest(r, &req); err != nil {
+		respondWithError(w, "INVALID_REQUEST_FORMAT", "Invalid request body", "", http.StatusBadRequest)
+		return
+	}
+	persona, ok := personadomain.DefaultRegistry().Get(req.PersonaID)
+	if !ok {
+		respondWithError(w, "UNKNOWN_PERSONA", "Persona was not found", req.PersonaID, http.StatusBadRequest)
+		return
+	}
+	result, err := buildPresetAuthorStyle(persona)
+	if err != nil {
+		respondWithError(w, "AUTHOR_STYLE_PRESET_FAILED", "Failed to build persona preset", err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := workflowStore.SaveAuthorStyle(result); err != nil {
+		respondWithError(w, "AUTHOR_STYLE_SAVE_FAILED", "Failed to save author style", err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, toAuthorStyleResponse(result))
 }
 
 // AnalyzeAuthorStyleHandler analyzes a note author and stores the resulting style assets.
@@ -155,6 +204,74 @@ func refineStyleGuideWithModel(ctx context.Context, result authorstyleapp.Analyz
 	return generator.Generate(ctx, prompt)
 }
 
+func buildPresetAuthorStyle(persona personadomain.Persona) (authorstyleapp.AnalyzeResult, error) {
+	fetchedAt := time.Now().UTC()
+	content := strings.Join([]string{
+		persona.Description,
+		persona.VoiceNotes.Tone,
+		strings.Join(persona.VoiceNotes.FirstPerson, " "),
+		strings.Join(persona.VoiceNotes.TitlePatterns, " "),
+		strings.Repeat(" "+strings.Join(persona.VoiceNotes.AntiPatterns, " "), 2),
+	}, "\n\n")
+	if strings.TrimSpace(content) == "" {
+		content = persona.DisplayName + " writing preset"
+	}
+	articleURL := "preset://" + persona.ID
+	if len(persona.Sources) > 0 && strings.TrimSpace(persona.Sources[0].URL) != "" {
+		articleURL = persona.Sources[0].URL
+	}
+	article := articledomain.Article{
+		URL:     articleURL,
+		Title:   persona.DisplayName + " preset",
+		Content: strings.Repeat(content+"\n\n", 8),
+	}
+	source := authordomain.AuthorSource{
+		Username: persona.ID,
+		Articles: []authordomain.SourceArticle{{
+			ID:    persona.ID + "_preset",
+			URL:   articleURL,
+			Title: article.Title,
+			At:    fetchedAt,
+		}},
+		FetchedAt: fetchedAt,
+	}
+	profile, err := authordomain.BuildAuthorStyleProfile(source, []articledomain.Article{article})
+	if err != nil {
+		return authorstyleapp.AnalyzeResult{}, err
+	}
+	if len(persona.VoiceNotes.FirstPerson) > 0 {
+		profile.PreferredFirstPerson = persona.VoiceNotes.FirstPerson[0]
+	}
+	guide, err := authordomain.BuildWritingStyleGuide(profile)
+	if err != nil {
+		return authorstyleapp.AnalyzeResult{}, err
+	}
+	if len(persona.VoiceNotes.FirstPerson) > 0 {
+		guide.PreferredFirstPerson = persona.VoiceNotes.FirstPerson[0]
+	}
+	guide.RecurringThemes = append([]string(nil), persona.VoiceNotes.TitlePatterns...)
+	if len(guide.RecurringThemes) == 0 {
+		guide.RecurringThemes = []string{persona.DisplayName, "技術", "体験"}
+	}
+	guide.ParagraphRhythm = persona.VoiceNotes.Tone
+	guide.HeadingGuidance = "出力先の形式に合わせ、読者が流れを追いやすい見出しを置く"
+	guide.OpeningPatterns = append([]string(nil), persona.VoiceNotes.TitlePatterns...)
+	guide.ConclusionPatterns = []string{"読者が次に試せる具体的な一歩で締める"}
+	guide.Warnings = append([]string{"persona_preset_without_live_fetch"}, persona.VoiceNotes.AntiPatterns...)
+	guide.Markdown = authordomain.GuideMarkdown(guide)
+	if err := guide.Validate(); err != nil {
+		return authorstyleapp.AnalyzeResult{}, err
+	}
+	return authorstyleapp.AnalyzeResult{
+		ID:           authorstyleapp.ResultID(source, profile.ID, guide.ID),
+		Source:       source,
+		Profile:      profile,
+		Guide:        guide,
+		ArticleCount: 1,
+		CreatedAt:    fetchedAt,
+	}, nil
+}
+
 // GetAuthorStyleHandler returns a stored author style analysis result.
 func GetAuthorStyleHandler(w http.ResponseWriter, r *http.Request) {
 	id := pathValue(r, "id")
@@ -184,11 +301,26 @@ func CreateBriefSessionHandler(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(req.SessionID) == "" {
 		req.SessionID = newID("abs")
 	}
+	persona, ok := personadomain.DefaultRegistry().Get(req.PersonaID)
+	if !ok {
+		respondWithError(w, "UNKNOWN_PERSONA", "Persona was not found", req.PersonaID, http.StatusBadRequest)
+		return
+	}
+	formatID := outputformat.NormalizeID(req.OutputFormatID)
+	if strings.TrimSpace(req.OutputFormatID) == "" {
+		formatID = persona.DefaultFormat
+	}
+	if _, ok := outputformat.DefaultRegistry().Get(formatID); !ok {
+		respondWithError(w, "UNKNOWN_OUTPUT_FORMAT", "Output format was not found", formatID, http.StatusBadRequest)
+		return
+	}
 
 	service := newBriefInterviewService(req.BriefModel)
 	result, err := service.StartSession(briefapp.StartSessionInput{
 		SessionID:      req.SessionID,
 		StyleProfileID: req.StyleProfileID,
+		PersonaID:      persona.ID,
+		OutputFormatID: formatID,
 		Questions:      toDomainQuestions(req.Questions),
 	})
 	if err != nil {
@@ -284,6 +416,29 @@ func GenerateDraftHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		articleBrief = session.AssembleBrief()
 	}
+	personaID := strings.TrimSpace(req.PersonaID)
+	formatID := strings.TrimSpace(req.OutputFormatID)
+	if personaID == "" {
+		personaID = articleBrief.PersonaID
+	}
+	if formatID == "" {
+		formatID = articleBrief.OutputFormatID
+	}
+	persona, ok := personadomain.DefaultRegistry().Get(personaID)
+	if !ok {
+		respondWithError(w, "UNKNOWN_PERSONA", "Persona was not found", personaID, http.StatusBadRequest)
+		return
+	}
+	if formatID == "" {
+		formatID = persona.DefaultFormat
+	}
+	format, ok := outputformat.DefaultRegistry().Get(formatID)
+	if !ok {
+		respondWithError(w, "UNKNOWN_OUTPUT_FORMAT", "Output format was not found", formatID, http.StatusBadRequest)
+		return
+	}
+	articleBrief.PersonaID = persona.ID
+	articleBrief.OutputFormatID = format.ID
 
 	generator, err := llamacpp.NewClientFromEnvForPurposeWithModel("DRAFT", req.DraftModel)
 	if err != nil {
@@ -295,6 +450,8 @@ func GenerateDraftHandler(w http.ResponseWriter, r *http.Request) {
 		StyleGuide:    guide,
 		Brief:         articleBrief,
 		AuthorProfile: profile,
+		Persona:       persona,
+		OutputFormat:  format,
 	})
 	if err != nil {
 		respondWithError(w, "DRAFT_GENERATION_FAILED", "Failed to generate draft", err.Error(), http.StatusInternalServerError)
@@ -344,13 +501,16 @@ func toBriefSessionResponse(result briefapp.InterviewResult) briefSessionRespons
 		}
 	}
 	return briefSessionResponse{
-		SessionID:      result.Session.ID,
-		StyleProfileID: result.Session.StyleProfileID,
-		Phase:          string(result.Session.Phase),
-		Completed:      result.Completed || result.Session.Completed,
-		NextQuestion:   question,
-		Brief:          result.Brief,
-		Answers:        result.Session.Answers,
+		SessionID:       result.Session.ID,
+		StyleProfileID:  result.Session.StyleProfileID,
+		PersonaID:       result.Session.PersonaID,
+		OutputFormatID:  result.Session.OutputFormatID,
+		ParentSessionID: result.Session.ParentSessionID,
+		Phase:           string(result.Session.Phase),
+		Completed:       result.Completed || result.Session.Completed,
+		NextQuestion:    question,
+		Brief:           result.Brief,
+		Answers:         result.Session.Answers,
 	}
 }
 

--- a/internal/handlers/workflow_mode_test.go
+++ b/internal/handlers/workflow_mode_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListPersonasHandler(t *testing.T) {
+	response := httptest.NewRecorder()
+	ListPersonasHandler(response, httptest.NewRequest(http.MethodGet, "/api/personas", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.Code, response.Body.String())
+	}
+	var payload []struct {
+		ID            string `json:"id"`
+		DefaultFormat string `json:"default_format"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode personas: %v", err)
+	}
+	if len(payload) < 2 {
+		t.Fatalf("personas = %d, want at least 2", len(payload))
+	}
+	if payload[0].ID != "terisuke" || payload[0].DefaultFormat == "" {
+		t.Fatalf("unexpected first persona: %#v", payload[0])
+	}
+}
+
+func TestListFormatsHandler(t *testing.T) {
+	response := httptest.NewRecorder()
+	ListFormatsHandler(response, httptest.NewRequest(http.MethodGet, "/api/formats", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.Code, response.Body.String())
+	}
+	var payload []struct {
+		ID           string `json:"id"`
+		RequiresMeta bool   `json:"requires_meta"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode formats: %v", err)
+	}
+	foundZenn := false
+	for _, format := range payload {
+		if format.ID == "zenn_article" && format.RequiresMeta {
+			foundZenn = true
+		}
+	}
+	if !foundZenn {
+		t.Fatalf("zenn_article format with metadata requirement not found: %#v", payload)
+	}
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -120,8 +120,25 @@ body {
 
 .config-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 14px;
+}
+
+.mode-summary {
+    display: grid;
+    gap: 4px;
+    margin: 8px 0 14px;
+    padding: 12px;
+    border: 1px solid var(--line);
+    border-left: 4px solid var(--primary);
+    border-radius: 6px;
+    background: #f8fafc;
+    color: var(--muted);
+    font-size: 14px;
+}
+
+.mode-summary strong {
+    color: var(--text);
 }
 
 .section-heading {

--- a/static/index.html
+++ b/static/index.html
@@ -31,6 +31,14 @@
 
         <div class="config-grid">
           <div class="field-row">
+            <label for="persona-select">書き手</label>
+            <select id="persona-select"></select>
+          </div>
+          <div class="field-row">
+            <label for="format-select">出力先</label>
+            <select id="format-select"></select>
+          </div>
+          <div class="field-row">
             <label for="style-model">文体分析モデル</label>
             <select id="style-model"></select>
           </div>
@@ -43,6 +51,7 @@
             <select id="draft-model"></select>
           </div>
         </div>
+        <div id="mode-summary" class="mode-summary" aria-live="polite"></div>
 
         <div class="question-config">
           <div class="section-heading">
@@ -60,9 +69,9 @@
         <div class="panel-header">
           <div>
             <span class="step-label">1</span>
-            <h2>文体分析</h2>
+            <h2>文体分析 / プリセット</h2>
           </div>
-          <p>Note記事を収集し、再利用できる文体ガイドを作ります。</p>
+          <p>note記事の分析、または書き手プリセットから再利用できる文体ガイドを作ります。</p>
         </div>
 
         <div class="field-row">
@@ -78,7 +87,10 @@
             <option value="8">8</option>
           </select>
         </div>
-        <button id="analyze-style-btn" class="primary-btn">文体を分析</button>
+        <div class="button-row">
+          <button id="analyze-style-btn" class="primary-btn">文体を分析</button>
+          <button id="use-preset-style-btn" class="secondary-btn" type="button">選択中の書き手プリセットを使う</button>
+        </div>
 
         <div id="style-result" class="result-box hidden">
           <div class="result-grid">

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -18,10 +18,15 @@ document.addEventListener('DOMContentLoaded', () => {
     sessionId: '',
     nextQuestion: null,
     completedBrief: null,
+    personas: [],
+    formats: [],
   };
 
   const el = {
     modelStatus: document.getElementById('model-status'),
+    personaSelect: document.getElementById('persona-select'),
+    formatSelect: document.getElementById('format-select'),
+    modeSummary: document.getElementById('mode-summary'),
     styleModel: document.getElementById('style-model'),
     briefModel: document.getElementById('brief-model'),
     draftModel: document.getElementById('draft-model'),
@@ -31,6 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     username: document.getElementById('style-username'),
     limit: document.getElementById('style-limit'),
     analyzeStyle: document.getElementById('analyze-style-btn'),
+    usePresetStyle: document.getElementById('use-preset-style-btn'),
     styleResult: document.getElementById('style-result'),
     profileId: document.getElementById('profile-id'),
     guideId: document.getElementById('guide-id'),
@@ -57,14 +63,18 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   renderQuestionConfig();
+  initializeModeControls();
   checkModels();
 
+  el.personaSelect.addEventListener('change', onPersonaChange);
+  el.formatSelect.addEventListener('change', onFormatChange);
   el.styleModel.addEventListener('change', saveModelConfig);
   el.briefModel.addEventListener('change', saveModelConfig);
   el.draftModel.addEventListener('change', saveModelConfig);
   el.addQuestion.addEventListener('click', addQuestion);
   el.resetQuestions.addEventListener('click', resetQuestions);
   el.analyzeStyle.addEventListener('click', analyzeStyle);
+  el.usePresetStyle.addEventListener('click', usePresetStyle);
   el.startInterview.addEventListener('click', startInterview);
   el.submitAnswer.addEventListener('click', submitAnswer);
   el.skipDeepDive.addEventListener('click', skipDeepDive);
@@ -74,6 +84,23 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.tab-btn').forEach((button) => {
     button.addEventListener('click', () => setActiveTab(button.dataset.tab));
   });
+
+  async function initializeModeControls() {
+    try {
+      const [personas, formats] = await Promise.all([
+        requestJSON('/api/personas'),
+        requestJSON('/api/formats'),
+      ]);
+      state.personas = personas;
+      state.formats = formats;
+      populatePersonaSelect();
+      populateFormatSelect();
+      applyPersonaDefaults(false);
+      renderModeSummary();
+    } catch (error) {
+      showError(`書き分け設定の取得に失敗しました: ${error.message}`);
+    }
+  }
 
   async function checkModels() {
     try {
@@ -105,19 +132,42 @@ document.addEventListener('DOMContentLoaded', () => {
           style_model: el.styleModel.value,
         },
       });
-      state.profileId = data.profile_id;
-      el.profileId.textContent = data.profile_id;
-      el.guideId.textContent = data.guide_id;
-      el.articleCount.textContent = String(data.article_count);
-      el.guidePreview.textContent = data.guide_markdown;
-      el.styleResult.classList.remove('hidden');
-      el.startInterview.disabled = false;
+      applyStyleResult(data);
       el.startInterview.focus();
     } catch (error) {
       showError(`文体分析に失敗しました: ${error.message}`);
     } finally {
       setLoading(false);
     }
+  }
+
+  async function usePresetStyle() {
+    clearError();
+    setLoading(true, '選択中の書き手プリセットを準備しています...');
+    try {
+      const data = await requestJSON('/api/author-style/seed', {
+        method: 'POST',
+        body: {
+          persona_id: currentPersonaId(),
+        },
+      });
+      applyStyleResult(data);
+      el.startInterview.focus();
+    } catch (error) {
+      showError(`プリセット文体の準備に失敗しました: ${error.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function applyStyleResult(data) {
+    state.profileId = data.profile_id;
+    el.profileId.textContent = data.profile_id;
+    el.guideId.textContent = data.guide_id;
+    el.articleCount.textContent = String(data.article_count);
+    el.guidePreview.textContent = data.guide_markdown;
+    el.styleResult.classList.remove('hidden');
+    el.startInterview.disabled = false;
   }
 
   async function startInterview() {
@@ -132,6 +182,8 @@ document.addEventListener('DOMContentLoaded', () => {
         method: 'POST',
         body: {
           style_profile_id: state.profileId,
+          persona_id: currentPersonaId(),
+          output_format_id: currentFormatId(),
           brief_model: el.briefModel.value,
           questions: currentQuestions(),
         },
@@ -204,6 +256,8 @@ document.addEventListener('DOMContentLoaded', () => {
         body: {
           style_profile_id: state.profileId,
           session_id: state.sessionId,
+          persona_id: currentPersonaId(),
+          output_format_id: currentFormatId(),
           draft_model: el.draftModel.value,
         },
       });
@@ -234,6 +288,77 @@ document.addEventListener('DOMContentLoaded', () => {
     setOptions(el.briefModel, available, defaults.brief);
     setOptions(el.draftModel, available, defaults.draft);
     saveModelConfig();
+  }
+
+  function populatePersonaSelect() {
+    el.personaSelect.innerHTML = '';
+    state.personas.forEach((persona) => {
+      const option = document.createElement('option');
+      option.value = persona.id;
+      option.textContent = persona.display_name;
+      option.selected = persona.id === config.mode.persona;
+      el.personaSelect.appendChild(option);
+    });
+    if (!el.personaSelect.value && state.personas[0]) {
+      el.personaSelect.value = state.personas[0].id;
+    }
+  }
+
+  function populateFormatSelect() {
+    el.formatSelect.innerHTML = '';
+    state.formats.forEach((format) => {
+      const option = document.createElement('option');
+      option.value = format.id;
+      option.textContent = format.display_name;
+      option.selected = format.id === config.mode.format;
+      el.formatSelect.appendChild(option);
+    });
+  }
+
+  function onPersonaChange() {
+    config.mode.persona = currentPersonaId();
+    applyPersonaDefaults(true);
+    saveConfig();
+    renderModeSummary();
+  }
+
+  function onFormatChange() {
+    config.mode.format = currentFormatId();
+    saveConfig();
+    renderModeSummary();
+    renderQuestionConfig();
+  }
+
+  function applyPersonaDefaults(forceFormat) {
+    const persona = currentPersona();
+    if (!persona) {
+      return;
+    }
+    const noteSource = (persona.sources || []).find((source) => source.kind === 'note' && source.ref);
+    if (noteSource && el.username.value.trim() === 'cor_instrument') {
+      el.username.value = noteSource.ref;
+    }
+    if ((forceFormat || !el.formatSelect.value) && persona.default_format) {
+      el.formatSelect.value = persona.default_format;
+      config.mode.format = persona.default_format;
+    }
+    renderQuestionConfig();
+  }
+
+  function renderModeSummary() {
+    const persona = currentPersona();
+    const format = currentFormat();
+    if (!persona || !format) {
+      el.modeSummary.textContent = '';
+      return;
+    }
+    const firstPerson = persona.voice_notes?.first_person?.join(' / ') || '';
+    const sources = (persona.sources || []).map((source) => source.kind).join(' + ');
+    el.modeSummary.innerHTML = `
+      <strong>${escapeHTML(persona.display_name)} × ${escapeHTML(format.display_name)}</strong>
+      <span>${escapeHTML(persona.description || '')}</span>
+      <span>一人称: ${escapeHTML(firstPerson || '文体ガイド優先')} / source: ${escapeHTML(sources || 'manual')}</span>
+    `;
   }
 
   function setOptions(select, models, selected) {
@@ -305,7 +430,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function currentQuestions() {
-    return config.questions
+    return [...config.questions, ...formatQuestions(currentFormatId())]
       .map((question) => ({
         id: question.id,
         text: question.text.trim(),
@@ -315,12 +440,57 @@ document.addEventListener('DOMContentLoaded', () => {
       .filter((question) => question.id && question.text);
   }
 
+  function formatQuestions(formatId) {
+    if (formatId === 'markdown_blog') {
+      return [
+        { id: 'cor_blog_purpose', text: '会社ブログとしての主目的は何ですか？例: 技術知見の報告、実装判断の共有、社員へのビジョン共有。', flow_type: 'main', target_field: 'custom' },
+        { id: 'cor_blog_category', text: 'カテゴリは ai / engineering / founder / lab のどれにしますか？理由も教えてください。', flow_type: 'main', target_field: 'custom' },
+        { id: 'cor_blog_metadata', text: 'slug候補、タグ3-5個、featuredの有無、画像パスがあれば指定してください。', flow_type: 'main', target_field: 'custom' },
+        { id: 'cor_blog_evidence', text: '本文に入れる具体的な実装、検証結果、数値、意思決定の根拠は何ですか？', flow_type: 'main', target_field: 'custom' },
+        { id: 'cor_blog_next_action', text: '社員や読者に、この記事を読んだ後どんな判断や行動をしてほしいですか？', flow_type: 'main', target_field: 'custom' },
+      ];
+    }
+    if (formatId === 'zenn_article' || formatId === 'qiita_article') {
+      return [
+        { id: 'target_stack', text: '対象技術スタック、バージョン、実行環境は何ですか？', flow_type: 'main', target_field: 'custom' },
+        { id: 'prerequisite_knowledge', text: '読者に前提として求める知識と、説明を厚くする箇所はどこですか？', flow_type: 'main', target_field: 'custom' },
+        { id: 'code_examples', text: '必ず入れるコード例、コマンド、設定ファイルは何ですか？', flow_type: 'main', target_field: 'custom' },
+        { id: 'references', text: '参照すべき公式ドキュメント、記事、リポジトリURLはありますか？', flow_type: 'main', target_field: 'custom' },
+      ];
+    }
+    if (formatId === 'homepage_section') {
+      return [
+        { id: 'target_conversion', text: 'このHTMLセクションで読者に起こしてほしい行動は何ですか？', flow_type: 'main', target_field: 'custom' },
+        { id: 'primary_cta', text: 'CTAの文言とリンク先は何にしますか？', flow_type: 'main', target_field: 'custom' },
+        { id: 'brand_voice', text: '会社サイトとして守りたい言い回し、避けたい表現はありますか？', flow_type: 'main', target_field: 'custom' },
+      ];
+    }
+    return [];
+  }
+
+  function currentPersonaId() {
+    return el.personaSelect.value || config.mode.persona || 'terisuke';
+  }
+
+  function currentFormatId() {
+    return el.formatSelect.value || config.mode.format || 'note_article';
+  }
+
+  function currentPersona() {
+    return state.personas.find((persona) => persona.id === currentPersonaId());
+  }
+
+  function currentFormat() {
+    return state.formats.find((format) => format.id === currentFormatId());
+  }
+
   function isFixedQuestion(id) {
     return defaultQuestions.some((question) => question.id === id);
   }
 
   function loadConfig() {
     const fallback = {
+      mode: { persona: 'terisuke', format: 'note_article' },
       models: { style: 'gemma4:latest', brief: 'gemma4:e2b', draft: 'gemma4:31b' },
       questions: cloneQuestions(defaultQuestions),
     };
@@ -328,6 +498,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const saved = JSON.parse(localStorage.getItem(configStorageKey) || '{}');
       return {
         models: { ...fallback.models, ...(saved.models || {}) },
+        mode: { ...fallback.mode, ...(saved.mode || {}) },
         questions: Array.isArray(saved.questions) && saved.questions.length
           ? saved.questions
           : fallback.questions,
@@ -351,6 +522,15 @@ document.addEventListener('DOMContentLoaded', () => {
     item.textContent = text;
     el.questionLog.appendChild(item);
     el.questionLog.scrollTop = el.questionLog.scrollHeight;
+  }
+
+  function escapeHTML(value) {
+    return String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;');
   }
 
   function renderDraft(data) {


### PR DESCRIPTION
## Summary
- Add Persona and OutputFormat registries, API selectors, and format-aware draft validation.
- Add embedded Markdown guides for note, Cor.inc blog, Zenn, Qiita, and homepage output so the final draft prompt receives the selected platform's notation rules.
- Update ADR-0002 and the implementation plan to reflect the shipped Phase B strategy.

## Issue mapping
Closes #21
Refs #23 #24 #25

B3 is advanced but not closed because scenario samples under tmp/format_samples are still outstanding. B4 and B5 are also advanced but keep their remaining scenario/server-side question-template acceptance criteria.

## Validation
- go test ./...
- node --check static/js/script.js