### PR TITLE
Refresh next implementation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note記事のURLまたはユーザー名を入力し、ローカルLLMが新し�
 
 ADR 0001 を踏まえた次の進化方針は [ADR 0002 — Multi-Persona, Multi-Format Article Generation](docs/adrs/0002-multi-persona-multi-format-extension.md) と [Multi-persona / multi-format 実装計画](docs/implementation-plans/multi-persona-multi-format.md) にまとめています。てりすけ本人と架空キャラ「宇宙野クラウディア」を別人格として扱い、note / cor-jp.com ブログ / Zenn / Qiita / ホームページHTML を切り替え可能にします。
 
-実装 issue と ADR の対応、各層の責務、テスト条件は [Issue and ADR guardrails](docs/implementation-plans/issue-adr-guardrails.md) にまとめています。
+実装 issue と ADR の対応、各層の責務、テスト条件は [Issue and ADR guardrails](docs/implementation-plans/issue-adr-guardrails.md) にまとめています。次に着手する実装順は [Next implementation cut](docs/implementation-plans/next-implementation-cut.md) に整理しています。
 
 ## 主な機能
 

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -194,14 +194,29 @@ The full work is broken into four phases tracked by issues. Each phase is indepe
   - Handler test coverage, Issue [#11](https://github.com/terisuke/note_maker/issues/11) (style threshold), Issue [#13](https://github.com/terisuke/note_maker/issues/13) (Playwright), Issue [#15](https://github.com/terisuke/note_maker/issues/15) (desktop packaging) follow-up.
   - Issue: [#29](https://github.com/terisuke/note_maker/issues/29).
 
-Recommended order: A → C → B → D. Phase C is sequenced before B because the persona registry needs durable storage to be useful; running B on the JSON store would force a second migration.
+Recommended order: A → C → B → D. Phase C is sequenced before the remaining B work because the persona registry needs durable storage to be useful; running the full persona library on the JSON store would force a second migration.
+
+Current implementation status as of 2026-05-02:
+
+- ADR 0001's strict Terisuke style threshold work is complete ([#11](https://github.com/terisuke/note_maker/issues/11)).
+- Phase B1 is complete ahead of the original order: `Persona` and `OutputFormat` concepts, prompt dispatch, and format validators are in place ([#21](https://github.com/terisuke/note_maker/issues/21)). The remaining Phase B work stays deferred until after Phase A/C foundations.
+- Evo X2 is the primary heavy-inference runtime through the Tailnet OpenAI-compatible API (`http://evo-x2:11434/v1`). SSH tunnel access is an explicit developer diagnostic only.
+- Runtime validation showed that Tailnet inference can take 20+ minutes and still miss quality gates because of generation variance. Therefore, Phase A should start with streaming and cancellation ([#18](https://github.com/terisuke/note_maker/issues/18)) before the broader transcript rewrite ([#17](https://github.com/terisuke/note_maker/issues/17)). Primary-runtime quality stabilization is tracked separately in [#40](https://github.com/terisuke/note_maker/issues/40).
+
+Near-term execution order:
+
+1. [#18](https://github.com/terisuke/note_maker/issues/18) — streaming LLM responses, progress events, and cancellation for Tailnet Evo X2.
+2. [#17](https://github.com/terisuke/note_maker/issues/17) — chat transcript and editable answer/fork UX, using the streaming primitives from #18.
+3. [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale display inside the transcript.
+4. [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate once streamed drafts are visible and cancellable.
+5. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts.
 
 ## Tracked issues
 
 Filed 2026-05-02 as part of the PR that introduced this ADR.
 
 - A1 — [#17](https://github.com/terisuke/note_maker/issues/17) Refactor interview UI to chat-style transcript with editable past answers
-- A2 — [#18](https://github.com/terisuke/note_maker/issues/18) Stream LLM responses via SSE for follow-up and draft generation
+- A2 — [#18](https://github.com/terisuke/note_maker/issues/18) Stream LLM responses via SSE for follow-up and draft generation. Promoted to the immediate next implementation target because Tailnet Evo X2 generation is too slow for a spinner-only UX.
 - A3 — [#19](https://github.com/terisuke/note_maker/issues/19) Editable draft Markdown + per-section regenerate API
 - A4 — [#20](https://github.com/terisuke/note_maker/issues/20) Surface deep-dive question rationale in prompt and UI
 - B1 — [#21](https://github.com/terisuke/note_maker/issues/21) Introduce Persona and OutputFormat domain concepts (registry + strategy). Implemented by the first Phase B PR: `internal/domain/persona`, `internal/domain/format`, API selectors, prompt dispatch, and format-aware draft validation.

--- a/docs/implementation-plans/issue-adr-guardrails.md
+++ b/docs/implementation-plans/issue-adr-guardrails.md
@@ -17,10 +17,11 @@ Open issues that ADR 0002 reframes (see [ADR 0002 — Tracked issues](../adrs/00
 
 | Issue | Scope | ADR Section | Guardrail |
 | --- | --- | --- | --- |
-| [#11](https://github.com/terisuke/note_maker/issues/11) | Strict style threshold tuning | ADR 0001 Draft Generation | Thresholds remain code-level; tuning may be revised once `first_person` density is computed per persona (ADR 0002 §Persona). |
 | [#13](https://github.com/terisuke/note_maker/issues/13) | Browser E2E for model config and question CRUD | ADR 0002 §Testing Strategy | Phase D folds persona switch, format switch, edit-and-fork, streaming, regenerate-section into the E2E surface. |
 | [#14](https://github.com/terisuke/note_maker/issues/14) | Persistent queryable database | ADR 0002 §Persistence direction | SQLite migration is the acceptance for #14; multi-persona schema is mandatory. |
 | [#15](https://github.com/terisuke/note_maker/issues/15) | Desktop launcher packaging | Out of ADR 0002 scope | Tracked separately; depends on Phase C completion before packaging makes sense. |
+| [#36](https://github.com/terisuke/note_maker/issues/36) | local llama.cpp fallback quality | ADR 0001/0002 runtime validation | Non-blocking for Phase A. Do not promote fallback as production-quality until it passes strict draft thresholds. |
+| [#40](https://github.com/terisuke/note_maker/issues/40) | Tailnet Evo X2 primary quality and runtime metrics | ADR 0001/0002 runtime validation | Primary runtime must record endpoint/model/elapsed/score/runes and distinguish generation variance from transport failures. |
 
 Closed historical issues:
 
@@ -30,12 +31,15 @@ Closed historical issues:
 | [#4](https://github.com/terisuke/note_maker/issues/4) | Resilient Note acquisition | Provides article acquisition adapter for author style analysis. |
 | [#5](https://github.com/terisuke/note_maker/issues/5) | DDD boundary split | Provides package boundary precedent. |
 | [#6](https://github.com/terisuke/note_maker/issues/6) | API contract alignment | Existing compatibility endpoint remains while new workflow is added. |
+| [#11](https://github.com/terisuke/note_maker/issues/11) | Strict style threshold tuning | Threshold logic is in place; future persona-specific revisions must be tracked separately. |
+| [#21](https://github.com/terisuke/note_maker/issues/21) | Persona and OutputFormat domain concepts | B1 landed early; remaining B work must not expand persistence assumptions until Phase C. |
 
 ## ADR 0002 Phase Map
 
 The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (A, B, C, D) are tracked as separate issues in the new tranche. Their guardrails extend the rules below:
 
 - Phase A (Conversation UX): no domain changes, only handler streaming + frontend rewrite. Must keep all existing `go test ./...` green without modification.
+- Phase A execution starts with [#18](https://github.com/terisuke/note_maker/issues/18) because Tailnet Evo X2 runs are long enough that spinner-only UX is no longer acceptable. [#17](https://github.com/terisuke/note_maker/issues/17) follows and reuses the streaming primitives.
 - Phase B (Persona / OutputFormat): introduces `internal/domain/persona` and `internal/domain/format`. The note.com host check moves out of application services into `internal/infrastructure/source/note` only.
 - Phase C (SQLite store): repository interfaces stay; only implementations change. JSON-file store becomes import/export utility.
 - Phase D (Quality): handler tests are mandatory before any further endpoint additions land. Coverage gate: `internal/handlers/workflow.go` ≥ 80 %.
@@ -59,6 +63,7 @@ The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (
    - Local llama.cpp (`http://127.0.0.1:8081/v1`) is fallback only. Do not set `LLM_BASE_URL` to local Ollama or local llama.cpp for Evo X2 validation unless the test is explicitly measuring fallback behavior.
    - Runtime validation must report base URL, model, elapsed time, score, and draft length.
    - If fallback validation fails the strict draft thresholds, keep Evo X2 primary enabled and track fallback hardening separately (Issue [#36](https://github.com/terisuke/note_maker/issues/36)).
+   - If Tailnet Evo X2 reaches the API but misses quality gates, track it under Issue [#40](https://github.com/terisuke/note_maker/issues/40), not as a transport regression.
 
 4. Handlers are JSON boundaries.
    - They create/use application services.

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -28,6 +28,25 @@ The four phases below match ADR 0002. Each is independently shippable.
 
 Recommended order: **A → C → B → D**. Phase B benefits from durable storage (Phase C) being in place first, otherwise the JSON store becomes a temporary obstacle for the persona registry.
 
+Current status after the 2026-05-02 merges:
+
+- [#11](https://github.com/terisuke/note_maker/issues/11) strict Terisuke style tuning is closed.
+- [#21](https://github.com/terisuke/note_maker/issues/21) B1 landed early: persona/format domain concepts, prompt dispatch, selectors, and validators exist.
+- [#38](https://github.com/terisuke/note_maker/issues/38) Tailnet OpenAI-compatible API is now the Evo X2 primary path. SSH tunnel access is diagnostic-only.
+- [#36](https://github.com/terisuke/note_maker/issues/36) remains open for local llama.cpp fallback quality; it does not block Phase A work.
+- [#40](https://github.com/terisuke/note_maker/issues/40) tracks primary Tailnet Evo X2 quality and runtime-metric stabilization.
+- A Tailnet full-workflow run reached the correct Evo X2 endpoint but took `1396.80s` and failed the quality gate (`score=82.0`, `2653` runes, `first_person=49`). This is the practical reason to start with streaming/cancellation rather than more prompt-only tuning.
+
+Near-term implementation cut:
+
+| Order | Issue | Why now | Done when |
+|---|---|---|---|
+| 1 | [#18](https://github.com/terisuke/note_maker/issues/18) | Long Tailnet inference needs visible progress, heartbeat, and cancellation before more UX is layered on top. | Draft generation streams to the UI, can be cancelled, and reports endpoint/model/elapsed time. |
+| 2 | [#17](https://github.com/terisuke/note_maker/issues/17) | The transcript can then use the streaming primitives instead of another spinner path. | Answers render as editable bubbles and edits fork the in-memory session. |
+| 3 | [#20](https://github.com/terisuke/note_maker/issues/20) | Deep-dive rationale belongs in the transcript once the transcript exists. | Every follow-up references the parent answer in prompt and UI. |
+| 4 | [#19](https://github.com/terisuke/note_maker/issues/19) | Section regeneration is useful only after draft output can stream and be cancelled. | Markdown is editable, preview syncs, and section regeneration replaces only one subtree. |
+| 5 | [#26](https://github.com/terisuke/note_maker/issues/26) | Forked answers and draft versions need durable storage before broader persona library work. | SQLite stores sessions, answers, guides, articles, and draft versions. |
+
 ## Phase A — Conversation UX
 
 ### A1 — Chat-style transcript with editable past answers
@@ -48,11 +67,16 @@ Acceptance:
 - Add SSE support to `internal/infrastructure/llamacpp/client.go` (OpenAI-compatible `stream: true`).
 - Wire streaming through the application services for `follow-up generation` and `draft generation`. Style analysis can stay non-streaming (single short call).
 - Frontend: replace global spinner with token-by-token append into the transcript (for follow-up) or into the draft preview (for draft).
+- Tailnet runtime: stream status events before first token (`endpoint`, `model`, `phase`, `started_at`), heartbeat events every 10 seconds, and final metrics (`elapsed_ms`, `runes`, `score` when available).
+- Cancellation: closing the browser request or pressing Cancel must cancel the server context and the upstream OpenAI-compatible request.
+- Failure mode: if the stream ends because the model times out or quality validation fails, keep the partial draft and surface the evaluation instead of losing the work.
 
 Acceptance:
 
-- A 3000-character draft visibly streams; first token < 3s on `gemma4:31b` warm.
+- A 3000-character draft visibly streams; a status event appears immediately and content chunks append incrementally once the model responds.
 - Network tab shows `text/event-stream` content type with incremental chunks.
+- Cancelling during a Tailnet Evo X2 run stops the server-side request and leaves the UI in a recoverable state.
+- Scenario/validation output records base URL, model, elapsed time, draft length, and score.
 
 ### A3 — Editable draft + per-section regenerate
 
@@ -280,4 +304,4 @@ Runtime validation treats Evo X2's OpenAI-compatible API over Tailscale VPN/Magi
 
 ## Immediate next implementation step
 
-Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. Start with **[#17](https://github.com/terisuke/note_maker/issues/17)** (chat transcript) on a feature branch off `develop`.
+Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. Start with **[#18](https://github.com/terisuke/note_maker/issues/18)** (SSE streaming, progress, and cancellation) on a feature branch off `develop`, then fold the transcript work from [#17](https://github.com/terisuke/note_maker/issues/17) on top of those streaming primitives.

--- a/docs/implementation-plans/next-implementation-cut.md
+++ b/docs/implementation-plans/next-implementation-cut.md
@@ -1,0 +1,56 @@
+# Next implementation cut
+
+Date: 2026-05-02
+
+This document translates the current open issue set into the next executable implementation sequence after the Tailnet Evo X2 runtime fixes.
+
+## Current issue state
+
+Closed and incorporated:
+
+- [#11](https://github.com/terisuke/note_maker/issues/11) — strict Terisuke style tuning.
+- [#21](https://github.com/terisuke/note_maker/issues/21) — Persona and OutputFormat domain concepts.
+- [#38](https://github.com/terisuke/note_maker/issues/38) — Evo X2 Tailnet OpenAI-compatible API as primary runtime.
+
+Open and active:
+
+- Phase A: [#17](https://github.com/terisuke/note_maker/issues/17), [#18](https://github.com/terisuke/note_maker/issues/18), [#19](https://github.com/terisuke/note_maker/issues/19), [#20](https://github.com/terisuke/note_maker/issues/20).
+- Phase B remaining: [#22](https://github.com/terisuke/note_maker/issues/22), [#23](https://github.com/terisuke/note_maker/issues/23), [#24](https://github.com/terisuke/note_maker/issues/24), [#25](https://github.com/terisuke/note_maker/issues/25).
+- Phase C: [#26](https://github.com/terisuke/note_maker/issues/26), [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28), extending [#14](https://github.com/terisuke/note_maker/issues/14).
+- Quality and packaging: [#13](https://github.com/terisuke/note_maker/issues/13), [#15](https://github.com/terisuke/note_maker/issues/15), [#29](https://github.com/terisuke/note_maker/issues/29), [#36](https://github.com/terisuke/note_maker/issues/36).
+- Runtime stabilization: [#40](https://github.com/terisuke/note_maker/issues/40) for primary Tailnet Evo X2 quality/metrics.
+
+## Next target
+
+Start with [#18](https://github.com/terisuke/note_maker/issues/18), not [#17](https://github.com/terisuke/note_maker/issues/17).
+
+Reason: a real Tailnet Evo X2 scenario reached the correct endpoint but took `1396.80s` and still missed quality gates. A spinner-only UI is not usable at that latency. Streaming, heartbeat, cancellation, and partial-result retention are the highest-leverage improvement before reshaping the transcript.
+
+## Implementation sequence
+
+1. **[#18] SSE streaming and cancellation**
+   - Add streaming to `internal/infrastructure/llamacpp`.
+   - Add status, heartbeat, token, done, and error event types.
+   - Support cancellation from browser disconnect and explicit Cancel.
+   - Keep non-streaming generation for tests and compatibility.
+
+2. **[#17] Chat transcript and editable answers**
+   - Replace the bounded log with a transcript surface.
+   - Render existing fixed and deep-dive answers as bubbles.
+   - Add in-memory fork-on-edit endpoint first; persistence follows in Phase C.
+
+3. **[#20] Deep-dive rationale in transcript**
+   - Add parent-answer excerpts to prompt and UI.
+   - Ensure LLM and rule-based fallback paths produce the same contextual prefix.
+
+4. **[#19] Editable draft and section regenerate**
+   - Make the Markdown draft editable after streaming lands.
+   - Add section anchor parsing and replacement tests.
+   - Regenerate one heading subtree at a time.
+
+5. **[#26] SQLite persistence**
+   - Persist answer forks, draft versions, guide versions, and project/article history.
+
+## Additional gap
+
+[#40](https://github.com/terisuke/note_maker/issues/40) tracks primary-runtime quality and runtime metrics. That work is separate from [#36](https://github.com/terisuke/note_maker/issues/36), which is only for local llama.cpp fallback quality. Do not block [#18](https://github.com/terisuke/note_maker/issues/18) on #40; streaming is needed precisely because these long primary-runtime runs can fail late and still need to preserve partial output.


### PR DESCRIPTION
## Summary

- Update ADR 0002 with the actual merged state after #11, #21, and Tailnet Evo X2 runtime work.
- Add docs/implementation-plans/next-implementation-cut.md with the next executable implementation sequence.
- Promote #18 as the next implementation target, followed by #17, #20, #19, and #26.
- Update guardrails to separate local fallback quality (#36) from primary Tailnet runtime quality (#40).
- Link the new next-cut document from README.

## Issue updates performed

- Added Tailnet streaming/cancellation/heartbeat requirements to #18.
- Added sequencing note to #17.
- Added streaming/Tailnet E2E expectations to #13.
- Marked #36 as non-blocking for Phase A.
- Created #40 for Tailnet Evo X2 primary quality/runtime metrics.
- Closed stale roadmap meta #30.

## Validation

- go test ./...
- git diff --check

Closes #41