### PR TITLE
Implement #17 chat transcript answer forks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,6 +40,8 @@ func main() {
 	r.HandleFunc("/api/brief-sessions", handlers.CreateBriefSessionHandler).Methods("POST")
 	r.HandleFunc("/api/brief-sessions/{id}", handlers.GetBriefSessionHandler).Methods("GET")
 	r.HandleFunc("/api/brief-sessions/{id}/answers", handlers.AnswerBriefSessionHandler).Methods("POST")
+	r.HandleFunc("/api/brief-sessions/{id}/answers/{answer_id}/edit", handlers.EditBriefAnswerHandler).Methods("POST")
+	r.HandleFunc("/api/sessions/{id}/answers/{answer_id}/edit", handlers.EditBriefAnswerHandler).Methods("POST")
 	r.HandleFunc("/api/drafts", handlers.GenerateDraftHandler).Methods("POST")
 
 	// ルートパスへのアクセスはindex.htmlにリダイレクト

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -204,15 +204,15 @@ Current implementation status as of 2026-05-02:
 - Phase model defaults are intentionally split: lightweight `gemma4:e2b` for source/style summarization, `qwen3.6:27b` for deeper interview questions, and `gemma4:31b` for final Japanese draft generation. This is an operational default, not a hard domain rule; users can override it per phase.
 - Final verification uses lightweight Gemma by default (`gemma4:latest`, currently the Evo X2 E4B-class Ollama model) to check brief coverage, style consistency, output-format notation, and unsupported factual assertions before the UI presents the final draft ([#47](https://github.com/terisuke/note_maker/issues/47)).
 - Runtime validation showed that Tailnet inference can take 20+ minutes and still miss quality gates because of generation variance. Therefore, Phase A started with streaming and cancellation ([#18](https://github.com/terisuke/note_maker/issues/18)) before the broader transcript rewrite ([#17](https://github.com/terisuke/note_maker/issues/17)). Primary-runtime quality stabilization is tracked separately in [#40](https://github.com/terisuke/note_maker/issues/40).
-- Phase A2 is implemented in code: `llamacpp.Client.GenerateStream`, streaming follow-up/draft service paths, `Accept: text/event-stream` handlers, browser Cancel controls, heartbeat events, and final runtime metrics. It still requires real Tailnet Evo X2 validation before closing the issue.
+- Phase A2 is implemented and merged: `llamacpp.Client.GenerateStream`, streaming follow-up/draft service paths, `Accept: text/event-stream` handlers, browser Cancel controls, heartbeat events, and final runtime metrics ([#18](https://github.com/terisuke/note_maker/issues/18)).
+- Phase A1 is implemented in code: the interview surface now renders a chat-style transcript, answer bubbles can be edited inline, and edits create child sessions via fork-on-edit while retaining `parent_session_id` lineage ([#17](https://github.com/terisuke/note_maker/issues/17)).
 
 Near-term execution order:
 
-1. Validate and merge [#18](https://github.com/terisuke/note_maker/issues/18) — streaming LLM responses, progress events, and cancellation for Tailnet Evo X2.
-2. [#17](https://github.com/terisuke/note_maker/issues/17) — chat transcript and editable answer/fork UX, using the streaming primitives from #18.
-3. [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale display inside the transcript.
-4. [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate once streamed drafts are visible and cancellable.
-5. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts.
+1. Merge [#17](https://github.com/terisuke/note_maker/issues/17) — chat transcript and editable answer/fork UX, using the streaming primitives from #18.
+2. [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale display inside the transcript.
+3. [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate once streamed drafts are visible and cancellable.
+4. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts.
 
 ## Tracked issues
 

--- a/docs/implementation-plans/issue-adr-guardrails.md
+++ b/docs/implementation-plans/issue-adr-guardrails.md
@@ -38,8 +38,8 @@ Closed historical issues:
 
 The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (A, B, C, D) are tracked as separate issues in the new tranche. Their guardrails extend the rules below:
 
-- Phase A (Conversation UX): no domain changes, only handler streaming + frontend rewrite. Must keep all existing `go test ./...` green without modification.
-- Phase A execution starts with [#18](https://github.com/terisuke/note_maker/issues/18) because Tailnet Evo X2 runs are long enough that spinner-only UX is no longer acceptable. [#17](https://github.com/terisuke/note_maker/issues/17) follows and reuses the streaming primitives.
+- Phase A (Conversation UX): keep domain changes narrow to auditable conversation state transitions such as fork-on-edit. Must keep all existing `go test ./...` green without weakening expectations.
+- Phase A execution started with [#18](https://github.com/terisuke/note_maker/issues/18) because Tailnet Evo X2 runs are long enough that spinner-only UX is no longer acceptable. [#17](https://github.com/terisuke/note_maker/issues/17) follows and reuses the streaming primitives.
 - Phase B (Persona / OutputFormat): introduces `internal/domain/persona` and `internal/domain/format`. The note.com host check moves out of application services into `internal/infrastructure/source/note` only.
 - Phase C (SQLite store): repository interfaces stay; only implementations change. JSON-file store becomes import/export utility.
 - Phase D (Quality): handler tests are mandatory before any further endpoint additions land. Coverage gate: `internal/handlers/workflow.go` ≥ 80 %.

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -41,8 +41,8 @@ Near-term implementation cut:
 
 | Order | Issue | Why now | Done when |
 |---|---|---|---|
-| 1 | [#18](https://github.com/terisuke/note_maker/issues/18) | Long Tailnet inference needs visible progress, heartbeat, and cancellation before more UX is layered on top. | Code streams follow-up/draft output, can be cancelled, and reports endpoint/model/elapsed time; final closure waits for Tailnet Evo X2 validation. |
-| 2 | [#17](https://github.com/terisuke/note_maker/issues/17) | The transcript can then use the streaming primitives instead of another spinner path. | Answers render as editable bubbles and edits fork the in-memory session. |
+| 1 | [#18](https://github.com/terisuke/note_maker/issues/18) | Long Tailnet inference needs visible progress, heartbeat, and cancellation before more UX is layered on top. | Implemented and merged. |
+| 2 | [#17](https://github.com/terisuke/note_maker/issues/17) | The transcript can then use the streaming primitives instead of another spinner path. | Implemented in code: answers render as editable bubbles and edits fork the in-memory session. |
 | 3 | [#20](https://github.com/terisuke/note_maker/issues/20) | Deep-dive rationale belongs in the transcript once the transcript exists. | Every follow-up references the parent answer in prompt and UI. |
 | 4 | [#19](https://github.com/terisuke/note_maker/issues/19) | Section regeneration is useful only after draft output can stream and be cancelled. | Markdown is editable, preview syncs, and section regeneration replaces only one subtree. |
 | 5 | [#26](https://github.com/terisuke/note_maker/issues/26) | Forked answers and draft versions need durable storage before broader persona library work. | SQLite stores sessions, answers, guides, articles, and draft versions. |
@@ -62,9 +62,11 @@ Acceptance:
 - Editing answer #2 in a 5-answer session produces a new session whose answers list is `[1, 2', …]`.
 - Original session is reachable from the new session via `parent_session_id`.
 
+Implementation note as of 2026-05-02: the static app implements this as a progressive enhancement without a SPA rewrite. The canonical route is `POST /api/brief-sessions/{id}/answers/{answer_id}/edit`; `/api/sessions/{id}/answers/{answer_id}/edit` remains as an ADR-compatible alias.
+
 ### A2 — Stream LLM responses via SSE
 
-Implementation status: code path implemented on `codex/issue-18-sse-streaming`; validate against real Tailnet Evo X2 before closing the issue.
+Implementation status: implemented and merged in [#18](https://github.com/terisuke/note_maker/issues/18).
 
 - Add SSE support to `internal/infrastructure/llamacpp/client.go` (OpenAI-compatible `stream: true`).
 - Wire streaming through the application services for `follow-up generation` and `draft generation`. Style analysis can stay non-streaming (single short call).
@@ -308,4 +310,4 @@ Draft generation now includes a lightweight final verification pass before retur
 
 ## Immediate next implementation step
 
-Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. Start with **[#18](https://github.com/terisuke/note_maker/issues/18)** (SSE streaming, progress, and cancellation) on a feature branch off `develop`, then fold the transcript work from [#17](https://github.com/terisuke/note_maker/issues/17) on top of those streaming primitives.
+Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. [#18](https://github.com/terisuke/note_maker/issues/18) is merged and [#17](https://github.com/terisuke/note_maker/issues/17) is implemented in code; after merging #17, continue with [#20](https://github.com/terisuke/note_maker/issues/20) so generated deep-dive questions expose their rationale inside the transcript.

--- a/docs/implementation-plans/next-implementation-cut.md
+++ b/docs/implementation-plans/next-implementation-cut.md
@@ -22,7 +22,7 @@ Open and active:
 
 ## Next target
 
-Start with [#18](https://github.com/terisuke/note_maker/issues/18), not [#17](https://github.com/terisuke/note_maker/issues/17).
+The ordering correction is now applied: [#18](https://github.com/terisuke/note_maker/issues/18) landed first, then [#17](https://github.com/terisuke/note_maker/issues/17) is being implemented on top of those streaming primitives.
 
 Reason: a real Tailnet Evo X2 scenario reached the correct endpoint but took `1396.80s` and still missed quality gates. A spinner-only UI is not usable at that latency. Streaming, heartbeat, cancellation, and partial-result retention are the highest-leverage improvement before reshaping the transcript.
 
@@ -33,12 +33,13 @@ Reason: a real Tailnet Evo X2 scenario reached the correct endpoint but took `13
    - Add status, heartbeat, token, done, and error event types.
    - Support cancellation from browser disconnect and explicit Cancel.
    - Keep non-streaming generation for tests and compatibility.
-   - Status: implemented in the current feature branch; close only after Tailnet Evo X2 OpenAI-compatible API validation and PR merge.
+   - Status: implemented and merged.
 
 2. **[#17] Chat transcript and editable answers**
    - Replace the bounded log with a transcript surface.
    - Render existing fixed and deep-dive answers as bubbles.
    - Add in-memory fork-on-edit endpoint first; persistence follows in Phase C.
+   - Status: implemented in code; merge before moving to #20.
 
 3. **[#20] Deep-dive rationale in transcript**
    - Add parent-answer excerpts to prompt and UI.

--- a/internal/application/brief/service.go
+++ b/internal/application/brief/service.go
@@ -74,6 +74,18 @@ func (s *InterviewService) AnswerStream(ctx context.Context, session domain.Arti
 	return s.answer(ctx, session, content, events)
 }
 
+// ForkAnswer edits an existing answer by creating a child session at that point.
+func (s *InterviewService) ForkAnswer(ctx context.Context, session domain.ArticleBriefSession, newSessionID, answerID, content string) (InterviewResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	fork, err := session.ForkWithEditedAnswer(newSessionID, answerID, content)
+	if err != nil {
+		return InterviewResult{}, err
+	}
+	return s.buildResultWithEvents(ctx, fork, StreamEvents{})
+}
+
 func (s *InterviewService) answer(ctx context.Context, session domain.ArticleBriefSession, content string, events StreamEvents) (InterviewResult, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/application/brief/service_test.go
+++ b/internal/application/brief/service_test.go
@@ -112,6 +112,45 @@ func TestInterviewServiceUsesFallbackWhenGeneratorFails(t *testing.T) {
 	}
 }
 
+func TestInterviewServiceForksEditedAnswerAndReturnsNextQuestion(t *testing.T) {
+	service := NewInterviewService(nil)
+	result, err := service.StartSession(StartSessionInput{
+		SessionID:      "session-1",
+		StyleProfileID: "style-1",
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	session := result.Session
+	for _, answer := range fixedAnswers()[:5] {
+		result, err = service.Answer(context.Background(), session, answer)
+		if err != nil {
+			t.Fatalf("answer fixed question: %v", err)
+		}
+		session = result.Session
+	}
+
+	result, err = service.ForkAnswer(context.Background(), session, "session-2", domain.QuestionIDOpeningEpisode, "Edited opening")
+	if err != nil {
+		t.Fatalf("fork answer: %v", err)
+	}
+	if result.Session.ID != "session-2" {
+		t.Fatalf("fork id = %q", result.Session.ID)
+	}
+	if result.Session.ParentSessionID != "session-1" {
+		t.Fatalf("parent session id = %q", result.Session.ParentSessionID)
+	}
+	if len(result.Session.Answers) != 2 {
+		t.Fatalf("answers = %d, want 2", len(result.Session.Answers))
+	}
+	if result.NextQuestion == nil || result.NextQuestion.ID != domain.QuestionIDReader {
+		t.Fatalf("next question = %#v", result.NextQuestion)
+	}
+	if session.Answers[1].Content != fixedAnswers()[1] {
+		t.Fatalf("original session was mutated: %#v", session.Answers[1])
+	}
+}
+
 func fixedAnswers() []string {
 	return []string{
 		"Local article generation with a small deterministic workflow.",

--- a/internal/domain/brief/session.go
+++ b/internal/domain/brief/session.go
@@ -60,6 +60,49 @@ func (s *ArticleBriefSession) RecordAnswer(content string) (ArticleQuestion, err
 	return question, nil
 }
 
+// ForkWithEditedAnswer creates a child session whose history is rewritten from one answer.
+func (s ArticleBriefSession) ForkWithEditedAnswer(newID, answerID, content string) (ArticleBriefSession, error) {
+	newID = strings.TrimSpace(newID)
+	answerID = strings.TrimSpace(answerID)
+	if newID == "" {
+		return ArticleBriefSession{}, fmt.Errorf("new session id is required")
+	}
+	if answerID == "" {
+		return ArticleBriefSession{}, fmt.Errorf("answer id is required")
+	}
+	answerIndex := -1
+	for i, answer := range s.Answers {
+		if answer.QuestionID == answerID {
+			answerIndex = i
+			break
+		}
+	}
+	if answerIndex < 0 {
+		return ArticleBriefSession{}, fmt.Errorf("answer %q was not found", answerID)
+	}
+	question, ok := s.questionForAnswer(s.Answers[answerIndex])
+	if !ok {
+		return ArticleBriefSession{}, fmt.Errorf("question metadata for answer %q was not found", answerID)
+	}
+	edited, err := NewBriefAnswer(question, content)
+	if err != nil {
+		return ArticleBriefSession{}, err
+	}
+
+	answers := make([]BriefAnswer, 0, answerIndex+1)
+	answers = append(answers, s.Answers[:answerIndex]...)
+	answers = append(answers, edited)
+
+	fork := s
+	fork.ID = newID
+	fork.ParentSessionID = s.ID
+	fork.Answers = answers
+	fork.Completed = false
+	fork.DeepDiveSkipped = false
+	fork.refreshPhase()
+	return fork, nil
+}
+
 // NewBriefAnswer normalizes answer content and copies question metadata onto the answer.
 func NewBriefAnswer(question ArticleQuestion, content string) (BriefAnswer, error) {
 	content = strings.TrimSpace(content)
@@ -366,6 +409,36 @@ func questionByID(questions []ArticleQuestion) map[string]ArticleQuestion {
 		result[question.ID] = question
 	}
 	return result
+}
+
+func (s ArticleBriefSession) questionForAnswer(answer BriefAnswer) (ArticleQuestion, bool) {
+	if answer.FlowType == QuestionFlowMain {
+		for _, question := range s.Questions {
+			if question.ID == answer.QuestionID {
+				return question, true
+			}
+		}
+		return ArticleQuestion{}, false
+	}
+	if answer.FlowType == QuestionFlowDeepDiveFollowUp {
+		targetField := "custom"
+		for _, question := range s.Questions {
+			if question.ID == answer.TargetQuestionID {
+				targetField = question.TargetField
+				break
+			}
+		}
+		return ArticleQuestion{
+			ID:               answer.QuestionID,
+			Text:             "Edited deep-dive answer",
+			FlowType:         QuestionFlowDeepDiveFollowUp,
+			Required:         true,
+			TargetField:      targetField,
+			TargetQuestionID: answer.TargetQuestionID,
+			FollowUpIndex:    answer.FollowUpIndex,
+		}, true
+	}
+	return ArticleQuestion{}, false
 }
 
 func isDeepDiveCandidate(content string) bool {

--- a/internal/domain/brief/session_test.go
+++ b/internal/domain/brief/session_test.go
@@ -175,6 +175,52 @@ func TestAssembleBriefIncludesFixedAndDeepDiveAnswers(t *testing.T) {
 	}
 }
 
+func TestForkWithEditedAnswerKeepsOriginalAndTruncatesFollowingAnswers(t *testing.T) {
+	session, err := NewArticleBriefSession("session-1", "style-1")
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	if _, err := session.RecordAnswer("Initial theme"); err != nil {
+		t.Fatalf("answer theme: %v", err)
+	}
+	if _, err := session.RecordAnswer("Initial opening"); err != nil {
+		t.Fatalf("answer opening: %v", err)
+	}
+	if _, err := session.RecordAnswer("Initial reader"); err != nil {
+		t.Fatalf("answer reader: %v", err)
+	}
+
+	fork, err := session.ForkWithEditedAnswer("session-2", QuestionIDOpeningEpisode, "Edited opening")
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	if fork.ID != "session-2" {
+		t.Fatalf("fork id = %q", fork.ID)
+	}
+	if fork.ParentSessionID != "session-1" {
+		t.Fatalf("parent session id = %q", fork.ParentSessionID)
+	}
+	if len(fork.Answers) != 2 {
+		t.Fatalf("fork answers = %d, want 2", len(fork.Answers))
+	}
+	if fork.Answers[0].QuestionID != QuestionIDTheme || fork.Answers[0].Content != "Initial theme" {
+		t.Fatalf("first fork answer = %#v", fork.Answers[0])
+	}
+	if fork.Answers[1].QuestionID != QuestionIDOpeningEpisode || fork.Answers[1].Content != "Edited opening" {
+		t.Fatalf("edited fork answer = %#v", fork.Answers[1])
+	}
+	if session.Answers[1].Content != "Initial opening" || len(session.Answers) != 3 {
+		t.Fatalf("original session was mutated: %#v", session.Answers)
+	}
+	next, ok := fork.CurrentQuestion()
+	if !ok {
+		t.Fatal("expected next question after fork")
+	}
+	if next.ID != QuestionIDReader {
+		t.Fatalf("next question = %q, want %q", next.ID, QuestionIDReader)
+	}
+}
+
 func TestGeneratedFollowUpQuestionRulesRejectBinaryQuestions(t *testing.T) {
 	disallowed := []string{
 		"Do you want the article to be practical?",

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -77,6 +77,11 @@ type answerBriefSessionRequest struct {
 	BriefModel   string `json:"brief_model"`
 }
 
+type editBriefAnswerRequest struct {
+	Content    string `json:"content"`
+	BriefModel string `json:"brief_model"`
+}
+
 type briefSessionResponse struct {
 	SessionID       string                    `json:"session_id"`
 	StyleProfileID  string                    `json:"style_profile_id"`
@@ -350,6 +355,37 @@ func GetBriefSessionHandler(w http.ResponseWriter, r *http.Request) {
 		result.Brief = &brief
 	} else if question, ok := session.CurrentQuestion(); ok {
 		result.NextQuestion = &question
+	}
+	respondWithJSON(w, http.StatusOK, toBriefSessionResponse(result))
+}
+
+// EditBriefAnswerHandler creates a new child session from an edited past answer.
+func EditBriefAnswerHandler(w http.ResponseWriter, r *http.Request) {
+	var req editBriefAnswerRequest
+	if err := decodeJSONRequest(r, &req); err != nil {
+		respondWithError(w, "INVALID_REQUEST_FORMAT", "Invalid request body", "", http.StatusBadRequest)
+		return
+	}
+	session, ok := workflowStore.GetSession(pathValue(r, "id"))
+	if !ok {
+		respondWithError(w, "BRIEF_SESSION_NOT_FOUND", "Brief session was not found", "", http.StatusNotFound)
+		return
+	}
+	service := newBriefInterviewService(req.BriefModel)
+	result, err := service.ForkAnswer(r.Context(), session, newID("abs"), pathValue(r, "answer_id"), req.Content)
+	if err != nil {
+		respondWithError(w, "BRIEF_ANSWER_EDIT_FAILED", "Failed to edit brief answer", err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := workflowStore.SaveSession(result.Session); err != nil {
+		respondWithError(w, "BRIEF_SESSION_SAVE_FAILED", "Failed to save brief session", err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if result.Completed && result.Brief != nil {
+		if err := workflowStore.SaveBrief(result.Session.ID, *result.Brief); err != nil {
+			respondWithError(w, "BRIEF_SAVE_FAILED", "Failed to save article brief", err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 	respondWithJSON(w, http.StatusOK, toBriefSessionResponse(result))
 }

--- a/internal/handlers/workflow_edit_test.go
+++ b/internal/handlers/workflow_edit_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	"github.com/teradakousuke/note_maker/internal/infrastructure/repository/memory"
+)
+
+func TestEditBriefAnswerHandlerForksSession(t *testing.T) {
+	workflowStore = memory.NewWorkflowStore()
+	session, err := briefdomain.NewArticleBriefSession("session-1", "style-1")
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	answers := []string{
+		"Local article generation.",
+		"Open with a failed local LLM run.",
+		"Solo developers.",
+		"Try a three-phase workflow.",
+		"Mention final checks.",
+	}
+	for _, answer := range answers {
+		if _, err := session.RecordAnswer(answer); err != nil {
+			t.Fatalf("record answer: %v", err)
+		}
+	}
+	if err := workflowStore.SaveSession(session); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"content":"Edited opening","brief_model":""}`)
+	request := httptest.NewRequest(http.MethodPost, "/api/brief-sessions/session-1/answers/opening_episode/edit", body)
+	request = mux.SetURLVars(request, map[string]string{
+		"id":        "session-1",
+		"answer_id": briefdomain.QuestionIDOpeningEpisode,
+	})
+	response := httptest.NewRecorder()
+
+	EditBriefAnswerHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var payload briefSessionResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.SessionID == "session-1" || payload.ParentSessionID != "session-1" {
+		t.Fatalf("unexpected session lineage: %#v", payload)
+	}
+	if len(payload.Answers) != 2 {
+		t.Fatalf("answers = %d, want 2", len(payload.Answers))
+	}
+	if payload.Answers[1].QuestionID != briefdomain.QuestionIDOpeningEpisode || payload.Answers[1].Content != "Edited opening" {
+		t.Fatalf("edited answer = %#v", payload.Answers[1])
+	}
+	original, ok := workflowStore.GetSession("session-1")
+	if !ok {
+		t.Fatal("original session was not retained")
+	}
+	if original.Answers[1].Content != answers[1] {
+		t.Fatalf("original answer changed: %#v", original.Answers[1])
+	}
+	if _, ok := workflowStore.GetSession(payload.SessionID); !ok {
+		t.Fatal("forked session was not saved")
+	}
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -264,36 +264,95 @@ pre {
 
 .question-log {
     display: grid;
-    gap: 10px;
-    max-height: 340px;
+    gap: 14px;
+    min-height: 420px;
+    max-height: min(68vh, 760px);
     overflow: auto;
     margin-bottom: 14px;
-    padding: 12px;
+    padding: 16px;
     background: #f8fafc;
     border: 1px solid var(--line);
     border-radius: 6px;
 }
 
-.log-item {
-    padding: 10px 12px;
-    border-radius: 6px;
-    background: var(--surface);
-    border: 1px solid var(--line);
+.transcript-item {
+    display: grid;
+    gap: 8px;
 }
 
-.log-item.answer {
-    margin-left: 52px;
+.transcript-item.answered {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.question-bubble,
+.answer-bubble {
+    width: min(82%, 760px);
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+}
+
+.question-bubble {
+    justify-self: start;
+}
+
+.question-bubble.current {
+    border-color: rgba(37, 99, 235, 0.32);
+}
+
+.answer-bubble {
+    justify-self: end;
     background: #eff6ff;
 }
 
-.log-item.deep-dive {
+.transcript-item.deep-dive .question-bubble {
     border-left: 4px solid var(--warning);
     background: var(--warning-bg);
 }
 
-.log-item.system {
-    color: var(--success);
-    background: var(--success-bg);
+.bubble-label {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.question-bubble p,
+.answer-bubble p {
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.parent-context {
+    margin: 10px 0 0;
+    padding: 8px 10px;
+    color: var(--muted);
+    background: rgba(255, 255, 255, 0.72);
+    border-left: 3px solid var(--line);
+    border-radius: 4px;
+    font-size: 13px;
+}
+
+.answer-edit-btn {
+    margin-top: 8px;
+    padding: 4px 8px;
+    color: var(--primary);
+    background: transparent;
+    border: 1px solid rgba(37, 99, 235, 0.28);
+    font-size: 13px;
+}
+
+.answer-edit-input {
+    min-height: 120px;
+}
+
+.edit-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
 }
 
 .status-line {
@@ -436,7 +495,8 @@ pre {
         grid-template-columns: 1fr;
     }
 
-    .log-item.answer {
-        margin-left: 0;
+    .question-bubble,
+    .answer-bubble {
+        width: 100%;
     }
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -16,10 +16,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const state = {
     profileId: '',
     sessionId: '',
+    parentSessionId: '',
     nextQuestion: null,
+    answers: [],
     completedBrief: null,
     personas: [],
     formats: [],
+    questionTextById: {},
+    lastSubmittedAnswer: '',
     answerAbortController: null,
     draftAbortController: null,
   };
@@ -84,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
   el.usePresetStyle.addEventListener('click', usePresetStyle);
   el.startInterview.addEventListener('click', startInterview);
   el.submitAnswer.addEventListener('click', submitAnswer);
+  el.answerInput.addEventListener('keydown', onAnswerInputKeydown);
   el.cancelAnswer.addEventListener('click', () => state.answerAbortController?.abort());
   el.skipDeepDive.addEventListener('click', skipDeepDive);
   el.generateDraft.addEventListener('click', generateDraft);
@@ -198,10 +203,16 @@ document.addEventListener('DOMContentLoaded', () => {
         },
       });
       state.sessionId = data.session_id;
+      state.parentSessionId = data.parent_session_id || '';
       state.nextQuestion = data.next_question;
+      state.answers = data.answers || [];
+      state.completedBrief = null;
+      rememberQuestions(currentQuestions());
+      rememberQuestion(data.next_question);
       el.interviewArea.classList.remove('hidden');
-      el.questionLog.innerHTML = '';
-      renderQuestion(data.next_question);
+      el.briefResult.classList.add('hidden');
+      el.generateDraft.disabled = true;
+      renderTranscript(data);
     } catch (error) {
       showError(`取材開始に失敗しました: ${error.message}`);
     } finally {
@@ -216,7 +227,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showError('回答を入力してください');
       return;
     }
-    appendLog('answer', content);
+    state.lastSubmittedAnswer = content;
     el.answerInput.value = '';
     await sendAnswer({ content });
   }
@@ -247,7 +258,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let streamedQuestionItem = null;
     state.answerAbortController = new AbortController();
     setAnswerStreaming(true);
-    appendLog('system', '回答を保存しています。');
     try {
       await requestSSE(`/api/brief-sessions/${state.sessionId}/answers`, {
         method: 'POST',
@@ -255,25 +265,15 @@ document.addEventListener('DOMContentLoaded', () => {
         signal: state.answerAbortController.signal,
         onEvent(event, data) {
           if (event === 'status') {
-            if (data.status === 'follow_up_generation_started') {
-              appendLog('system', '深掘り質問を生成しています。');
-            }
             return;
           }
           if (event === 'chunk') {
             streamedQuestion += data.text || '';
-            if (!streamedQuestionItem) {
-              streamedQuestionItem = appendLog('deep-dive', '');
-            }
-            streamedQuestionItem.textContent = streamedQuestion;
-            el.questionLog.scrollTop = el.questionLog.scrollHeight;
+            streamedQuestionItem = renderPendingQuestion(streamedQuestionItem, streamedQuestion);
             return;
           }
           if (event === 'result') {
-            applyInterviewResult(data, { questionAlreadyRendered: Boolean(streamedQuestionItem) });
-            if (streamedQuestionItem && data.next_question?.text) {
-              streamedQuestionItem.textContent = data.next_question.text;
-            }
+            applyInterviewResult(data);
             return;
           }
           if (event === 'error') {
@@ -283,7 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     } catch (error) {
       if (error.name === 'AbortError') {
-        appendLog('system', '処理を停止しました。途中までの内容は画面に残しています。');
+        renderPendingQuestion(streamedQuestionItem, streamedQuestion || '処理を停止しました。途中までの内容は画面に残しています。');
       } else {
         showError(`回答の保存に失敗しました: ${error.message}`);
       }
@@ -293,20 +293,25 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function applyInterviewResult(data, options = {}) {
+  function applyInterviewResult(data) {
+    state.sessionId = data.session_id || state.sessionId;
+    state.parentSessionId = data.parent_session_id || '';
+    state.answers = data.answers || [];
+    rememberQuestion(data.next_question);
+    renderTranscript(data);
     if (data.completed) {
       state.completedBrief = data.brief;
       state.nextQuestion = null;
       el.briefPreview.textContent = JSON.stringify(data.brief, null, 2);
       el.briefResult.classList.remove('hidden');
       el.generateDraft.disabled = false;
-      appendLog('system', '記事ブリーフが完成しました。');
+      el.skipDeepDive.classList.add('hidden');
       return;
     }
+    state.completedBrief = null;
     state.nextQuestion = data.next_question;
-    if (!options.questionAlreadyRendered) {
-      renderQuestion(data.next_question);
-    }
+    el.briefResult.classList.add('hidden');
+    el.generateDraft.disabled = true;
     el.skipDeepDive.classList.toggle('hidden', data.next_question?.flow_type !== 'deep_dive_follow_up');
   }
 
@@ -377,12 +382,235 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function renderQuestion(question) {
-    if (!question) {
+  function renderTranscript(data = {}) {
+    const answers = data.answers || state.answers || [];
+    const nextQuestion = data.next_question ?? state.nextQuestion;
+    el.questionLog.innerHTML = '';
+    answers.forEach((answer) => {
+      el.questionLog.appendChild(createTranscriptItem(answer));
+    });
+    if (nextQuestion && !data.completed) {
+      el.questionLog.appendChild(createPendingQuestionItem(nextQuestion));
+    }
+    el.questionLog.scrollTop = el.questionLog.scrollHeight;
+  }
+
+  function createTranscriptItem(answer) {
+    const questionId = answerValue(answer, 'question_id', 'QuestionID');
+    const flowType = answerValue(answer, 'flow_type', 'FlowType') || 'main';
+    const targetQuestionId = answerValue(answer, 'target_question_id', 'TargetQuestionID');
+    const item = document.createElement('div');
+    item.className = `transcript-item answered ${flowType === 'deep_dive_follow_up' ? 'deep-dive' : ''}`;
+
+    const questionBubble = document.createElement('div');
+    questionBubble.className = 'question-bubble';
+    const questionLabel = document.createElement('span');
+    questionLabel.className = 'bubble-label';
+    questionLabel.textContent = flowType === 'deep_dive_follow_up' ? '深掘り質問' : '質問';
+    const questionText = document.createElement('p');
+    questionText.textContent = questionTextForAnswer(answer);
+    questionBubble.append(questionLabel, questionText);
+    const parentContext = parentContextForAnswer(answer);
+    if (parentContext) {
+      questionBubble.appendChild(parentContext);
+    }
+
+    const answerBubble = document.createElement('div');
+    answerBubble.className = 'answer-bubble';
+    answerBubble.dataset.answerId = questionId;
+    if (targetQuestionId) {
+      answerBubble.dataset.targetQuestionId = targetQuestionId;
+    }
+    const answerLabel = document.createElement('span');
+    answerLabel.className = 'bubble-label';
+    answerLabel.textContent = '回答';
+    const answerText = document.createElement('p');
+    answerText.className = 'answer-text';
+    answerText.textContent = answerValue(answer, 'content', 'Content') || '';
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'answer-edit-btn';
+    editButton.textContent = '編集';
+    editButton.addEventListener('click', () => startAnswerEdit(answerBubble, answer));
+    answerBubble.append(answerLabel, answerText, editButton);
+
+    item.append(questionBubble, answerBubble);
+    return item;
+  }
+
+  function createPendingQuestionItem(question) {
+    rememberQuestion(question);
+    const item = document.createElement('div');
+    item.className = `transcript-item pending ${question.flow_type === 'deep_dive_follow_up' ? 'deep-dive' : ''}`;
+    const questionBubble = document.createElement('div');
+    questionBubble.className = 'question-bubble current';
+    const label = document.createElement('span');
+    label.className = 'bubble-label';
+    label.textContent = question.flow_type === 'deep_dive_follow_up' ? '次の深掘り質問' : '次の質問';
+    const text = document.createElement('p');
+    text.textContent = question.text || '質問を準備しています...';
+    questionBubble.append(label, text);
+    if (question.flow_type === 'deep_dive_follow_up') {
+      const context = parentContextForQuestion(question);
+      if (context) {
+        questionBubble.appendChild(context);
+      }
+    }
+    item.appendChild(questionBubble);
+    return item;
+  }
+
+  function renderPendingQuestion(existingItem, text) {
+    if (existingItem) {
+      const paragraph = existingItem.querySelector('p');
+      if (paragraph) {
+        paragraph.textContent = text;
+      }
+      el.questionLog.scrollTop = el.questionLog.scrollHeight;
+      return existingItem;
+    }
+    const item = createPendingQuestionItem({
+      id: 'streaming_follow_up',
+      text,
+      flow_type: 'deep_dive_follow_up',
+    });
+    el.questionLog.appendChild(item);
+    el.questionLog.scrollTop = el.questionLog.scrollHeight;
+    return item;
+  }
+
+  function startAnswerEdit(container, answer) {
+    const original = answerValue(answer, 'content', 'Content') || '';
+    container.innerHTML = '';
+    const textarea = document.createElement('textarea');
+    textarea.className = 'answer-edit-input';
+    textarea.rows = 5;
+    textarea.value = original;
+    const actions = document.createElement('div');
+    actions.className = 'edit-actions';
+    const save = document.createElement('button');
+    save.type = 'button';
+    save.className = 'primary-btn';
+    save.textContent = '保存して分岐';
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'secondary-btn';
+    cancel.textContent = 'キャンセル';
+    actions.append(save, cancel);
+    container.append(textarea, actions);
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    save.addEventListener('click', () => editAnswer(answer, textarea.value));
+    cancel.addEventListener('click', () => renderTranscript());
+  }
+
+  async function editAnswer(answer, content) {
+    clearError();
+    const trimmed = content.trim();
+    if (!trimmed) {
+      showError('回答を入力してください');
       return;
     }
-    appendLog(question.flow_type === 'deep_dive_follow_up' ? 'deep-dive' : 'question', question.text);
-    el.skipDeepDive.classList.toggle('hidden', question.flow_type !== 'deep_dive_follow_up');
+    const answerId = answerValue(answer, 'question_id', 'QuestionID');
+    setLoading(true, '回答を編集し、新しいセッションへ分岐しています...');
+    try {
+      const data = await requestJSON(`/api/brief-sessions/${state.sessionId}/answers/${encodeURIComponent(answerId)}/edit`, {
+        method: 'POST',
+        body: {
+          content: trimmed,
+          brief_model: el.briefModel.value,
+        },
+      });
+      state.lastSubmittedAnswer = trimmed;
+      applyInterviewResult(data);
+      el.answerInput.focus();
+    } catch (error) {
+      showError(`回答編集に失敗しました: ${error.message}`);
+      renderTranscript();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function rememberQuestions(questions) {
+    (questions || []).forEach(rememberQuestion);
+  }
+
+  function rememberQuestion(question) {
+    if (!question?.id || !question?.text) {
+      return;
+    }
+    state.questionTextById[question.id] = question.text;
+  }
+
+  function questionTextForAnswer(answer) {
+    const questionId = answerValue(answer, 'question_id', 'QuestionID');
+    const flowType = answerValue(answer, 'flow_type', 'FlowType') || 'main';
+    if (state.questionTextById[questionId]) {
+      return state.questionTextById[questionId];
+    }
+    if (flowType === 'deep_dive_follow_up') {
+      const targetQuestionId = answerValue(answer, 'target_question_id', 'TargetQuestionID');
+      const index = answerValue(answer, 'follow_up_index', 'FollowUpIndex');
+      const target = state.questionTextById[targetQuestionId] || targetQuestionId || '回答';
+      return `${target} への深掘り ${index || ''}`.trim();
+    }
+    return questionId || '質問';
+  }
+
+  function parentContextForAnswer(answer) {
+    const flowType = answerValue(answer, 'flow_type', 'FlowType') || 'main';
+    if (flowType !== 'deep_dive_follow_up') {
+      return null;
+    }
+    return parentContextForQuestion({
+      target_question_id: answerValue(answer, 'target_question_id', 'TargetQuestionID'),
+    });
+  }
+
+  function parentContextForQuestion(question) {
+    const targetQuestionId = question.target_question_id || question.TargetQuestionID;
+    if (!targetQuestionId) {
+      return null;
+    }
+    const parentAnswer = (state.answers || []).find((answer) => answerValue(answer, 'question_id', 'QuestionID') === targetQuestionId);
+    if (!parentAnswer) {
+      return null;
+    }
+    const context = document.createElement('blockquote');
+    context.className = 'parent-context';
+    const parentQuestion = state.questionTextById[targetQuestionId] || targetQuestionId;
+    const parentContent = answerValue(parentAnswer, 'content', 'Content') || '';
+    context.textContent = `${parentQuestion}: ${truncate(parentContent, 140)}`;
+    return context;
+  }
+
+  function answerValue(answer, snake, pascal) {
+    return answer?.[snake] ?? answer?.[pascal] ?? '';
+  }
+
+  function truncate(value, maxLength) {
+    const text = String(value || '');
+    return text.length > maxLength ? `${text.slice(0, maxLength - 1)}...` : text;
+  }
+
+  function onAnswerInputKeydown(event) {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault();
+      if (!el.submitAnswer.disabled) {
+        submitAnswer();
+      }
+      return;
+    }
+    if (event.key !== 'ArrowUp' || el.answerInput.value.trim() || !state.lastSubmittedAnswer) {
+      return;
+    }
+    if (el.answerInput.selectionStart !== 0 || el.answerInput.selectionEnd !== 0) {
+      return;
+    }
+    event.preventDefault();
+    el.answerInput.value = state.lastSubmittedAnswer;
+    el.answerInput.setSelectionRange(el.answerInput.value.length, el.answerInput.value.length);
   }
 
   function populateModelSelects(models) {
@@ -625,15 +853,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function cloneQuestions(questions) {
     return questions.map((question) => ({ ...question }));
-  }
-
-  function appendLog(kind, text) {
-    const item = document.createElement('div');
-    item.className = `log-item ${kind}`;
-    item.textContent = text;
-    el.questionLog.appendChild(item);
-    el.questionLog.scrollTop = el.questionLog.scrollHeight;
-    return item;
   }
 
   function escapeHTML(value) {


### PR DESCRIPTION
## Summary
- Add fork-on-edit support for interview answers with parent session lineage.
- Replace the bounded question log with a chat-style transcript and inline editable answer bubbles.
- Update ADR/implementation docs now that #18 is merged and #17 is implemented.

## Validation
- go test ./...
- node --check static/js/script.js
- curl http://127.0.0.1:8091/ and /api/personas against the local server

Closes #17