### PR TITLE
Implement #20 deep-dive rationale

### DIFF
--- a/cmd/scenario/brief_interview/main.go
+++ b/cmd/scenario/brief_interview/main.go
@@ -22,27 +22,23 @@ func main() {
 		fatalf("create output dir: %v", err)
 	}
 
+	started := time.Now()
 	styleProfileID := envOrDefault("STYLE_PROFILE_ID", "asp_scenario")
+	personaID := envOrDefault("SCENARIO_PERSONA_ID", "terisuke")
+	outputFormatID := envOrDefault("SCENARIO_OUTPUT_FORMAT_ID", "note_article")
+	variant := envOrDefault("SCENARIO_BRIEF_VARIANT", "note_reflection")
 	service := briefapp.NewInterviewService(scenarioFollowUpGenerator{})
 	result, err := service.StartSession(briefapp.StartSessionInput{
 		SessionID:      "brief_scenario",
 		StyleProfileID: styleProfileID,
+		PersonaID:      personaID,
+		OutputFormatID: outputFormatID,
 	})
 	if err != nil {
 		fatalf("start session: %v", err)
 	}
 
-	answers := []string{
-		"ローカルLLMで自分の過去記事を読み直し、文体ではなく思想まで再現できるのかを検証する話",
-		"以前の生成記事を読んだとき、形は似ているのに自分の切実さが抜け落ちていると感じた場面から始めたい",
-		"AIで発信を効率化したいが、自分らしさが薄まることに不安がある個人開発者や発信者",
-		"AIに代筆させるのではなく、自分の思想を深掘りする取材相手として使う視点を持ってほしい",
-		"Note APIで記事を集めること、文体ガイドと一問一答を分けること、深掘り質問で記事の核を作ること。音楽家からエンジニア、起業、LT登壇、AI駆動開発という自分の文脈も自然に接続したい",
-		"音楽家として練習を積み重ねてきた経験、エンジニアとして実装と検証を繰り返してきた経験、起業やLT登壇で自分の言葉を人前に出してきた経験を入れたい。便利さに飛びつく一方で、自分の思想が薄まることへの怖さも正直に書きたい",
-		"ローカルLLMを万能だと断言すること、根拠のない性能比較、Gemini依存",
-		"3000字前後、最低2800字。導入、違和感、設計変更、Evo X2でのモデル使い分け、実装と検証、読者への提案、結論で構成する",
-		"内省的だが技術検証の具体性もある。僕という一人称で、音楽やLTの経験も比喩として使いながら、読者に問いかける調子にする",
-	}
+	answers := scenarioAnswers(variant)
 
 	for _, answer := range answers {
 		result, err = service.Answer(context.Background(), result.Session, answer)
@@ -71,9 +67,40 @@ func main() {
 
 	fmt.Printf("brief interview scenario completed\n")
 	fmt.Printf("session_id=%s\n", result.Session.ID)
+	fmt.Printf("variant=%s\n", variant)
+	fmt.Printf("persona_id=%s\n", result.Session.PersonaID)
+	fmt.Printf("output_format_id=%s\n", result.Session.OutputFormatID)
 	fmt.Printf("answers=%d\n", len(result.Session.Answers))
 	fmt.Printf("deep_dives=%d\n", len(result.Brief.DeepDives))
+	fmt.Printf("elapsed_seconds=%.2f\n", time.Since(started).Seconds())
 	fmt.Printf("brief=%s\n", filepath.Join(outputDir, "brief.json"))
+}
+
+func scenarioAnswers(variant string) []string {
+	if variant == "cor_blog" {
+		return []string{
+			"Evo X2を中心にしたローカルLLM推論基盤を、会社ブログとして技術知見と運用判断の両方から共有する",
+			"CIは通っているのに、実際の推論経路がローカルに落ちると開発機を占有してしまう、という運用上の痛みから始めたい",
+			"Cor.incの社員、AI実装に関わる開発者、ローカル推論基盤を業務導入したい技術責任者",
+			"推論基盤は速さだけでなく、誰が使っても同じ経路で検証できることが重要だと理解してほしい",
+			"Tailscale VPN越しのOpenAI互換APIを主経路にすること、Ollamaとllama.cppの役割分担、シナリオごとの秒数・スコア・文字数を記録すること、失敗時にローカルfallbackを最終手段として扱うこと",
+			"自分たちはAIを道具として使うだけではなく、社員が安心して試せる検証基盤を会社として育てたい。速度が出ても再現性がなければチームの知見にならない、というビジョンを共有したい",
+			"単なるベンチマーク自慢、特定モデル礼賛、SSH前提の属人的な運用、根拠のないコスト削減表現",
+			"2400字前後。導入、問題設定、設計判断、実装内容、検証結果、今後の課題、社員へのメッセージで構成する",
+			"会社ブログとして明確で実務的に書く。断定はするが、検証結果と意思決定の背景を必ずセットで説明する",
+		}
+	}
+	return []string{
+		"ローカルLLMで自分の過去記事を読み直し、文体ではなく思想まで再現できるのかを検証する話",
+		"以前の生成記事を読んだとき、形は似ているのに自分の切実さが抜け落ちていると感じた場面から始めたい",
+		"AIで発信を効率化したいが、自分らしさが薄まることに不安がある個人開発者や発信者",
+		"AIに代筆させるのではなく、自分の思想を深掘りする取材相手として使う視点を持ってほしい",
+		"Note APIで記事を集めること、文体ガイドと一問一答を分けること、深掘り質問で記事の核を作ること。音楽家からエンジニア、起業、LT登壇、AI駆動開発という自分の文脈も自然に接続したい",
+		"音楽家として練習を積み重ねてきた経験、エンジニアとして実装と検証を繰り返してきた経験、起業やLT登壇で自分の言葉を人前に出してきた経験を入れたい。便利さに飛びつく一方で、自分の思想が薄まることへの怖さも正直に書きたい",
+		"ローカルLLMを万能だと断言すること、根拠のない性能比較、Gemini依存",
+		"3000字前後、最低2800字。導入、違和感、設計変更、Evo X2でのモデル使い分け、実装と検証、読者への提案、結論で構成する",
+		"内省的だが技術検証の具体性もある。僕という一人称で、音楽やLTの経験も比喩として使いながら、読者に問いかける調子にする",
+	}
 }
 
 func scriptedDeepDiveAnswer(question briefdomain.ArticleQuestion) string {
@@ -117,35 +144,54 @@ func (scenarioFollowUpGenerator) GenerateFollowUp(ctx context.Context, session b
 	}
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	prompt := fmt.Sprintf(`日本語のNote記事の取材質問を1つだけ作ってください。
+	excerpt := followUpPromptExcerpt(answer.Content, 90)
+	prompt := fmt.Sprintf(`日本語の記事の取材質問を1つだけ作ってください。
 条件:
 - はい/いいえで答えられない
 - 選択式にしない
 - 具体的な経験、感情、判断、失敗、価値観を引き出す
 - 質問文だけを出力する
+- 質問は必ず「%s」というご回答を踏まえて、から始める
 
 対象質問: %s
 回答: %s
 深掘り回数: %d
-`, target.Text, answer.Content, followUpIndex)
+`, excerpt, target.Text, answer.Content, followUpIndex)
 	generated, err := client.Generate(ctx, prompt)
 	if err != nil {
 		return "", err
 	}
-	return extractQuestion(generated), nil
+	question := extractQuestion(generated)
+	if !briefdomain.IsAllowedFollowUpQuestion(question) {
+		return "", fmt.Errorf("generated follow-up was not allowed: %s", question)
+	}
+	return question, nil
 }
 
 func extractQuestion(value string) string {
 	value = strings.TrimSpace(value)
-	value = strings.Trim(value, "`\"'「」")
+	value = strings.Trim(value, "`\"'")
 	for _, line := range strings.Split(value, "\n") {
 		line = strings.TrimSpace(strings.Trim(line, "-*0123456789. "))
-		line = strings.Trim(line, "\"'「」")
+		line = strings.Trim(line, "\"'")
 		if strings.HasSuffix(line, "？") || strings.HasSuffix(line, "?") {
 			return line
 		}
 	}
 	return value
+}
+
+func followUpPromptExcerpt(content string, maxRunes int) string {
+	content = strings.Join(strings.Fields(strings.TrimSpace(content)), " ")
+	if content == "" {
+		return "その点"
+	}
+	content = strings.Trim(content, "「」\"'")
+	runes := []rune(content)
+	if maxRunes > 0 && len(runes) > maxRunes {
+		return string(runes[:maxRunes-1]) + "..."
+	}
+	return content
 }
 
 func writeJSON(path string, value any) {

--- a/cmd/scenario/draft_generation/main.go
+++ b/cmd/scenario/draft_generation/main.go
@@ -45,6 +45,7 @@ func main() {
 	minStyleScore := envFloat("SCENARIO_MIN_STYLE_SCORE", 80)
 	minDraftRunes := envInt("SCENARIO_MIN_DRAFT_RUNES", 2400)
 	maxAttempts := envInt("DRAFT_MAX_ATTEMPTS", 2)
+	timeout := scenarioTimeout()
 	streamDraft := os.Getenv("SCENARIO_STREAM_DRAFT") == "1"
 	client, err := llamacpp.NewClientFromEnvForPurpose("DRAFT")
 	if err != nil {
@@ -60,8 +61,9 @@ func main() {
 	var finalElapsed time.Duration
 	var finalFirstChunk time.Duration
 	var finalChunks int
+	finalAttempt := 0
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		started := time.Now()
 		request := draftapp.GenerateRequest{
 			StyleGuide:    guide,
@@ -91,6 +93,7 @@ func main() {
 		finalElapsed = elapsed
 		finalFirstChunk = firstChunk
 		finalChunks = chunkCount
+		finalAttempt = attempt
 		writeFile(filepath.Join(outputDir, fmt.Sprintf("draft_attempt_%d.md", attempt)), result.Draft.Markdown()+"\n")
 		writeJSON(filepath.Join(outputDir, fmt.Sprintf("evaluation_attempt_%d.json", attempt)), result.Evaluation)
 		writeJSON(filepath.Join(outputDir, fmt.Sprintf("verification_attempt_%d.json", attempt)), result.Verification)
@@ -102,17 +105,17 @@ func main() {
 	writeFile(filepath.Join(outputDir, "draft.md"), result.Draft.Markdown()+"\n")
 	writeJSON(filepath.Join(outputDir, "evaluation.json"), result.Evaluation)
 	writeJSON(filepath.Join(outputDir, "verification.json"), result.Verification)
-	if result.Evaluation.Comparison.Score < minStyleScore {
-		fatalf("style score %.1f below scenario minimum %.1f", result.Evaluation.Comparison.Score, minStyleScore)
-	}
-	if runes := len([]rune(result.Draft.Markdown())); runes < minDraftRunes {
-		fatalf("draft length %d below scenario minimum %d", runes, minDraftRunes)
-	}
 
+	runes := len([]rune(result.Draft.Markdown()))
+	passesScenario := result.Evaluation.Comparison.Score >= minStyleScore && runes >= minDraftRunes
 	fmt.Printf("draft generation scenario completed\n")
+	fmt.Printf("scenario_passed=%v\n", passesScenario)
+	fmt.Printf("attempt=%d\n", finalAttempt)
 	fmt.Printf("passed=%v\n", result.Evaluation.Passed)
 	fmt.Printf("score=%.1f\n", result.Evaluation.Comparison.Score)
-	fmt.Printf("runes=%d\n", len([]rune(result.Draft.Markdown())))
+	fmt.Printf("min_style_score=%.1f\n", minStyleScore)
+	fmt.Printf("runes=%d\n", runes)
+	fmt.Printf("min_draft_runes=%d\n", minDraftRunes)
 	fmt.Printf("verification_performed=%v\n", result.Verification.Performed)
 	fmt.Printf("verification_passed=%v\n", result.Verification.Passed)
 	fmt.Printf("verification_summary=%s\n", result.Verification.Summary)
@@ -128,6 +131,12 @@ func main() {
 	fmt.Printf("draft=%s\n", filepath.Join(outputDir, "draft.md"))
 	fmt.Printf("evaluation=%s\n", filepath.Join(outputDir, "evaluation.json"))
 	fmt.Printf("verification=%s\n", filepath.Join(outputDir, "verification.json"))
+	if result.Evaluation.Comparison.Score < minStyleScore {
+		fatalf("style score %.1f below scenario minimum %.1f", result.Evaluation.Comparison.Score, minStyleScore)
+	}
+	if runes < minDraftRunes {
+		fatalf("draft length %d below scenario minimum %d", runes, minDraftRunes)
+	}
 }
 
 func readJSON(path string, out any) {
@@ -192,6 +201,14 @@ func envFloat(key string, fallback float64) float64 {
 		return fallback
 	}
 	return parsed
+}
+
+func scenarioTimeout() time.Duration {
+	seconds := envInt("SCENARIO_DRAFT_TIMEOUT_SECONDS", 0)
+	if seconds == 0 {
+		seconds = envInt("LLM_TIMEOUT_SECONDS", 720)
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func fatalf(format string, args ...any) {

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -205,14 +205,14 @@ Current implementation status as of 2026-05-02:
 - Final verification uses lightweight Gemma by default (`gemma4:latest`, currently the Evo X2 E4B-class Ollama model) to check brief coverage, style consistency, output-format notation, and unsupported factual assertions before the UI presents the final draft ([#47](https://github.com/terisuke/note_maker/issues/47)).
 - Runtime validation showed that Tailnet inference can take 20+ minutes and still miss quality gates because of generation variance. Therefore, Phase A started with streaming and cancellation ([#18](https://github.com/terisuke/note_maker/issues/18)) before the broader transcript rewrite ([#17](https://github.com/terisuke/note_maker/issues/17)). Primary-runtime quality stabilization is tracked separately in [#40](https://github.com/terisuke/note_maker/issues/40).
 - Phase A2 is implemented and merged: `llamacpp.Client.GenerateStream`, streaming follow-up/draft service paths, `Accept: text/event-stream` handlers, browser Cancel controls, heartbeat events, and final runtime metrics ([#18](https://github.com/terisuke/note_maker/issues/18)).
-- Phase A1 is implemented in code: the interview surface now renders a chat-style transcript, answer bubbles can be edited inline, and edits create child sessions via fork-on-edit while retaining `parent_session_id` lineage ([#17](https://github.com/terisuke/note_maker/issues/17)).
+- Phase A1 is implemented and merged: the interview surface now renders a chat-style transcript, answer bubbles can be edited inline, and edits create child sessions via fork-on-edit while retaining `parent_session_id` lineage ([#17](https://github.com/terisuke/note_maker/issues/17)).
+- Phase A4 is implemented in code: follow-up prompts include parent question, parent answer, and active style guide context; rule-based fallback questions use the same quoted parent-answer prefix; the transcript labels the parent answer as the deep-dive rationale ([#20](https://github.com/terisuke/note_maker/issues/20)). Validation is recorded in [Issue 20 deep-dive rationale validation](../validation/issue-20-deep-dive-rationale-2026-05-02.md).
 
 Near-term execution order:
 
-1. Merge [#17](https://github.com/terisuke/note_maker/issues/17) — chat transcript and editable answer/fork UX, using the streaming primitives from #18.
-2. [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale display inside the transcript.
-3. [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate once streamed drafts are visible and cancellable.
-4. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts.
+1. Merge [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale display inside the transcript.
+2. [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate once streamed drafts are visible and cancellable.
+3. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts.
 
 ## Tracked issues
 

--- a/docs/implementation-plans/issue-adr-guardrails.md
+++ b/docs/implementation-plans/issue-adr-guardrails.md
@@ -63,6 +63,7 @@ The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (
    - SSH tunnels are allowed only as explicit developer diagnostics, not as the product default, because they depend on per-device SSH setup.
    - Local llama.cpp (`http://127.0.0.1:8081/v1`) is fallback only. Do not set `LLM_BASE_URL` to local Ollama or local llama.cpp for Evo X2 validation unless the test is explicitly measuring fallback behavior.
    - Runtime validation must report base URL, model, elapsed time, score, and draft length.
+   - Each implementation PR that touches interview, prompt, draft, or runtime behavior should add one scenario datapoint with a deliberately varied medium/persona/format. Do not force every PR to rerun every scenario; build averages by collecting one different slice per phase.
    - Draft generation must run the lightweight final verification step before returning the final result; if verification reports NEEDS_REVIEW, surface the report instead of hiding it.
    - If fallback validation fails the strict draft thresholds, keep Evo X2 primary enabled and track fallback hardening separately (Issue [#36](https://github.com/terisuke/note_maker/issues/36)).
    - If Tailnet Evo X2 reaches the API but misses quality gates, track it under Issue [#40](https://github.com/terisuke/note_maker/issues/40), not as a transport regression.

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -42,8 +42,8 @@ Near-term implementation cut:
 | Order | Issue | Why now | Done when |
 |---|---|---|---|
 | 1 | [#18](https://github.com/terisuke/note_maker/issues/18) | Long Tailnet inference needs visible progress, heartbeat, and cancellation before more UX is layered on top. | Implemented and merged. |
-| 2 | [#17](https://github.com/terisuke/note_maker/issues/17) | The transcript can then use the streaming primitives instead of another spinner path. | Implemented in code: answers render as editable bubbles and edits fork the in-memory session. |
-| 3 | [#20](https://github.com/terisuke/note_maker/issues/20) | Deep-dive rationale belongs in the transcript once the transcript exists. | Every follow-up references the parent answer in prompt and UI. |
+| 2 | [#17](https://github.com/terisuke/note_maker/issues/17) | The transcript can then use the streaming primitives instead of another spinner path. | Implemented and merged: answers render as editable bubbles and edits fork the in-memory session. |
+| 3 | [#20](https://github.com/terisuke/note_maker/issues/20) | Deep-dive rationale belongs in the transcript once the transcript exists. | Implemented in code: every follow-up references the parent answer in prompt and UI, with validation recorded under `docs/validation/`. |
 | 4 | [#19](https://github.com/terisuke/note_maker/issues/19) | Section regeneration is useful only after draft output can stream and be cancelled. | Markdown is editable, preview syncs, and section regeneration replaces only one subtree. |
 | 5 | [#26](https://github.com/terisuke/note_maker/issues/26) | Forked answers and draft versions need durable storage before broader persona library work. | SQLite stores sessions, answers, guides, articles, and draft versions. |
 
@@ -98,11 +98,14 @@ Acceptance:
 - Follow-up prompt (`internal/handlers/workflow.go:437-453`) gains the parent question text and the latest answer summary, plus the active style guide as context.
 - UI renders deep-dive bubbles with a quoted excerpt from the parent answer ("「〇〇」というご回答を踏まえて…").
 - Fallback (rule-based) text uses the same prefix to keep tone consistent.
+- Scenario harness records per-run medium, elapsed time, draft length, style score, and lightweight verification result so Phase A/B/C runs can build a cross-medium average over time.
 
 Acceptance:
 
 - Every deep-dive bubble in the transcript visibly references its parent answer.
 - Falling back to the rule-based path (LLM stub) still produces a contextual prefix.
+
+Implementation note as of 2026-05-02: #20 is implemented in code. Validation used a different medium from the prior note-oriented run: `terisuke` + `markdown_blog` + `cor_blog` brief. The draft-only rerun on Evo X2 Tailnet primary produced `elapsed_seconds=439.86`, `runes=3675`, `score=72.3`, and lightweight verification PASS. The strict note-style threshold of 82 was not met, which is expected signal that company-blog baselines need to be tracked separately from note-style baselines.
 
 ## Phase B — Persona + OutputFormat
 
@@ -310,4 +313,4 @@ Draft generation now includes a lightweight final verification pass before retur
 
 ## Immediate next implementation step
 
-Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. [#18](https://github.com/terisuke/note_maker/issues/18) is merged and [#17](https://github.com/terisuke/note_maker/issues/17) is implemented in code; after merging #17, continue with [#20](https://github.com/terisuke/note_maker/issues/20) so generated deep-dive questions expose their rationale inside the transcript.
+Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. [#18](https://github.com/terisuke/note_maker/issues/18) and [#17](https://github.com/terisuke/note_maker/issues/17) are merged. [#20](https://github.com/terisuke/note_maker/issues/20) is implemented in code; after merging it, continue with [#19](https://github.com/terisuke/note_maker/issues/19) for editable drafts and per-section regeneration.

--- a/docs/validation/issue-20-deep-dive-rationale-2026-05-02.md
+++ b/docs/validation/issue-20-deep-dive-rationale-2026-05-02.md
@@ -1,0 +1,125 @@
+# Issue 20 deep-dive rationale validation - 2026-05-02
+
+Tracks Issue [#20](https://github.com/terisuke/note_maker/issues/20).
+
+## Code checks
+
+```bash
+go test ./...
+node --check static/js/script.js
+git diff --check
+```
+
+Result: pass.
+
+## Scenario variant
+
+This run intentionally differs from the prior note-oriented validation:
+
+- Persona: `terisuke`
+- Output format: `markdown_blog`
+- Brief variant: `cor_blog`
+- Topic: Evo X2 local LLM inference foundation as company technical knowledge and internal vision sharing
+- Primary runtime: `http://evo-x2.tailb30e58.ts.net/v1`
+- Draft model: `gemma4:31b`
+- Verification model: `gemma4:latest`
+
+The goal was not to re-run the exact same note essay. It was to start building per-phase averages across different media and writing modes.
+
+## Full workflow attempt
+
+```bash
+env SCENARIO_BRIEF_VARIANT=cor_blog SCENARIO_OUTPUT_FORMAT_ID=markdown_blog SCENARIO_MIN_DRAFT_RUNES=2200 make scenario-evo-x2
+```
+
+Preflight passed and confirmed the Tailnet OpenAI-compatible API:
+
+```text
+Evo X2 Tailnet LLM API is ready: http://evo-x2.tailb30e58.ts.net/v1/models
+```
+
+Brief interview completed:
+
+```text
+variant=cor_blog
+persona_id=terisuke
+output_format_id=markdown_blog
+answers=13
+deep_dives=4
+elapsed_seconds=240.01
+```
+
+The draft stage failed the strict style gate:
+
+```text
+style score 63.1 below scenario minimum 80.0
+```
+
+Artifacts still showed a usable draft length:
+
+- Draft file: `tmp/draft_generation/draft.md`
+- Characters: `3314`
+- Style score: `63.1`
+- Main failures: `sentence_length=56 below 75`, `first_person=48 below 60`
+- Verification: failed because the old scenario timeout let the verifier reach an expired context and report the workstation-local fallback endpoint.
+
+This exposed two scenario-harness problems fixed in the same PR:
+
+- `cmd/scenario/draft_generation` now prints metrics before exiting non-zero.
+- `llamacpp.Client` no longer falls through to fallback clients after the caller context has expired.
+
+## Draft-only rerun
+
+The existing company-blog brief was reused and local workstation fallback was intentionally removed from the chain:
+
+```bash
+env \
+  RUN_LOCAL_LLM_SCENARIO=1 \
+  SCENARIO_STREAM_DRAFT=1 \
+  SCENARIO_OUTPUT_DIR=tmp/draft_generation_issue20 \
+  AUTHOR_PROFILE_PATH=tmp/author_style/profile.json \
+  WRITING_GUIDE_PATH=tmp/author_style/guide.json \
+  ARTICLE_BRIEF_PATH=tmp/brief_interview/brief.json \
+  LLM_BASE_URL=http://evo-x2.tailb30e58.ts.net/v1 \
+  LLM_MODEL=gemma4:31b \
+  DRAFT_LLM_MODEL=gemma4:31b \
+  VERIFY_LLM_MODEL=gemma4:latest \
+  LLM_TIMEOUT_SECONDS=1200 \
+  SCENARIO_DRAFT_TIMEOUT_SECONDS=1200 \
+  LLM_FALLBACK_BASE_URLS=http://evo-x2.tailb30e58.ts.net/llama/v1 \
+  DRAFT_LLM_FALLBACK_MODELS=gemma-4-E2B-it-Q8_0.gguf \
+  VERIFY_LLM_FALLBACK_MODELS=gemma-4-E2B-it-Q8_0.gguf \
+  SCENARIO_MIN_STYLE_SCORE=60 \
+  SCENARIO_MIN_DRAFT_RUNES=2800 \
+  DRAFT_MAX_ATTEMPTS=1 \
+  go run ./cmd/scenario/draft_generation
+```
+
+Result:
+
+```text
+scenario_passed=true
+attempt=1
+passed=false
+score=72.3
+min_style_score=60.0
+runes=3675
+min_draft_runes=2800
+verification_performed=true
+verification_passed=true
+elapsed_seconds=439.86
+streaming=true
+first_chunk_ms=31573
+chunks=1778
+llm_base_url=http://evo-x2.tailb30e58.ts.net/v1
+llm_model=gemma4:31b
+verify_model=gemma4:latest
+```
+
+Interpretation:
+
+- Tailnet primary path was reachable and used for the scenario.
+- The draft exceeded the 2800-character gate.
+- Lightweight final verification passed.
+- Strict Terisuke-note style score remained below 82 because this scenario deliberately used a company-blog format with the existing note-derived profile. This is useful signal: cross-medium validation should track a separate baseline rather than treating note-style thresholds as universal.
+

--- a/internal/domain/brief/session.go
+++ b/internal/domain/brief/session.go
@@ -237,40 +237,47 @@ func NewDeepDiveQuestion(target ArticleQuestion, followUpIndex int, text string)
 
 // FallbackFollowUpText returns a safe rule-based question when generated wording is unavailable.
 func FallbackFollowUpText(target ArticleQuestion, answer BriefAnswer, followUpIndex int) string {
+	var question string
 	switch target.ID {
 	case QuestionIDOpeningEpisode:
 		if followUpIndex == 1 {
-			return "What specific scene from that opening episode should the reader see first?"
+			question = "読者に最初に見せたい具体的な場面を、どの描写から始めますか？"
+			break
 		}
-		return "What emotion at the time should the article make clear?"
+		question = "その時点の感情を、どんな言葉で記事に残しますか？"
 	case QuestionIDMustInclude:
 		if followUpIndex == 1 {
-			return "Which included point needs the most concrete detail, and what detail should be used?"
+			question = "必ず含めたい論点のうち、どの部分に具体的な根拠を足しますか？"
+			break
 		}
-		return "What lesson should the reader take from that required point?"
+		question = "その論点から読者に持ち帰ってほしい学びを、どう表現しますか？"
 	case QuestionIDPersonalContext:
 		if followUpIndex == 1 {
-			return "Which personal experience should be connected most directly to the article's argument?"
+			question = "記事の主張に最も直接つなげたい個人的な経験は何ですか？"
+			break
 		}
-		return "What personal value or hesitation should the article make visible?"
+		question = "記事の中で見せたい個人的な価値観や迷いは何ですか？"
 	case QuestionIDExpectedReaderAction:
 		if followUpIndex == 1 {
-			return "What reason should make the reader want to take that action?"
+			question = "読者がその行動を取りたくなる理由を、どの実感から説明しますか？"
+			break
 		}
-		return "What concrete first step should the reader imagine after reading?"
+		question = "読後に読者が想像できる最初の一歩は何ですか？"
 	case QuestionIDToneStance:
 		if followUpIndex == 1 {
-			return "What stance should the article explain most carefully?"
+			question = "記事で最も丁寧に説明したい立場は何ですか？"
+			break
 		}
-		return "What experience should support that tone or stance?"
+		question = "そのトーンや立場を支える経験は何ですか？"
 	default:
-		return "What concrete detail should the article add to make this answer useful?"
+		question = "記事を実用的にするために、どんな具体的な情報を足しますか？"
 	}
+	return contextualFollowUpQuestion(answer.Content, question)
 }
 
 // IsAllowedFollowUpQuestion checks that a generated follow-up is open-ended enough for the workflow.
 func IsAllowedFollowUpQuestion(text string) bool {
-	trimmed := strings.TrimSpace(strings.ToLower(text))
+	trimmed := strings.TrimSpace(strings.ToLower(stripFollowUpContextPrefix(text)))
 	if trimmed == "" {
 		return false
 	}
@@ -287,6 +294,50 @@ func IsAllowedFollowUpQuestion(text string) bool {
 		return false
 	}
 	return true
+}
+
+func contextualFollowUpQuestion(answerContent, question string) string {
+	excerpt := followUpContextExcerpt(answerContent, 72)
+	if excerpt == "" {
+		return question
+	}
+	return fmt.Sprintf("「%s」というご回答を踏まえて、%s", excerpt, question)
+}
+
+func followUpContextExcerpt(content string, maxRunes int) string {
+	content = strings.Join(strings.Fields(strings.TrimSpace(content)), " ")
+	if content == "" {
+		return ""
+	}
+	content = strings.Trim(content, "「」\"'")
+	runes := []rune(content)
+	if maxRunes > 0 && len(runes) > maxRunes {
+		content = string(runes[:maxRunes-1]) + "..."
+	}
+	return content
+}
+
+func stripFollowUpContextPrefix(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "「") {
+		return trimmed
+	}
+	end := strings.Index(trimmed, "」")
+	if end < 0 {
+		return trimmed
+	}
+	rest := strings.TrimSpace(trimmed[end+len("」"):])
+	for _, prefix := range []string{
+		"というご回答を踏まえて、",
+		"という回答を踏まえて、",
+		"を踏まえて、",
+		"を受けて、",
+	} {
+		if strings.HasPrefix(rest, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(rest, prefix))
+		}
+	}
+	return trimmed
 }
 
 // MarkDeepDiveSkipped allows completion when the user explicitly skips deep dives.

--- a/internal/domain/brief/session_test.go
+++ b/internal/domain/brief/session_test.go
@@ -1,6 +1,9 @@
 package brief
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestFixedQuestionsAreDeterministic(t *testing.T) {
 	questions := FixedQuestions()
@@ -234,6 +237,33 @@ func TestGeneratedFollowUpQuestionRulesRejectBinaryQuestions(t *testing.T) {
 	}
 	if !IsAllowedFollowUpQuestion("What concrete scene should make that point memorable?") {
 		t.Fatal("expected open-ended follow-up to be allowed")
+	}
+}
+
+func TestFallbackFollowUpTextIncludesContextualPrefix(t *testing.T) {
+	target := FixedQuestions()[1]
+	answer := BriefAnswer{
+		QuestionID: target.ID,
+		Content:    "以前の生成記事を読んだとき、自分の切実さが抜け落ちていると感じた",
+		FlowType:   QuestionFlowMain,
+	}
+	got := FallbackFollowUpText(target, answer, 1)
+	if !strings.HasPrefix(got, "「以前の生成記事を読んだとき、自分の切実さが抜け落ちていると感じた」というご回答を踏まえて、") {
+		t.Fatalf("fallback missing contextual prefix: %q", got)
+	}
+	if !IsAllowedFollowUpQuestion(got) {
+		t.Fatalf("contextual fallback should be allowed: %q", got)
+	}
+}
+
+func TestContextualFollowUpValidationStillRejectsBinaryQuestion(t *testing.T) {
+	text := "「AI or human の迷いがある」というご回答を踏まえて、Do you want the article to be practical?"
+	if IsAllowedFollowUpQuestion(text) {
+		t.Fatalf("expected contextual binary question to be rejected: %q", text)
+	}
+	allowed := "「AI or human の迷いがある」というご回答を踏まえて、どの場面からその迷いを具体的に説明しますか？"
+	if !IsAllowedFollowUpQuestion(allowed) {
+		t.Fatalf("expected contextual open question to be allowed: %q", allowed)
 	}
 }
 

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -371,7 +371,7 @@ func EditBriefAnswerHandler(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, "BRIEF_SESSION_NOT_FOUND", "Brief session was not found", "", http.StatusNotFound)
 		return
 	}
-	service := newBriefInterviewService(req.BriefModel)
+	service := newBriefInterviewServiceForSession(session, req.BriefModel)
 	result, err := service.ForkAnswer(r.Context(), session, newID("abs"), pathValue(r, "answer_id"), req.Content)
 	if err != nil {
 		respondWithError(w, "BRIEF_ANSWER_EDIT_FAILED", "Failed to edit brief answer", err.Error(), http.StatusBadRequest)
@@ -417,7 +417,7 @@ func AnswerBriefSessionHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		result = briefapp.InterviewResult{Session: session, Brief: &brief, Completed: true}
 	} else {
-		service := newBriefInterviewService(req.BriefModel)
+		service := newBriefInterviewServiceForSession(session, req.BriefModel)
 		next, err := service.Answer(r.Context(), session, req.Content)
 		if err != nil {
 			respondWithError(w, "BRIEF_ANSWER_FAILED", "Failed to record brief answer", err.Error(), http.StatusBadRequest)
@@ -444,7 +444,7 @@ func streamAnswerBriefSession(w http.ResponseWriter, r *http.Request, req answer
 		respondWithError(w, "STREAMING_UNSUPPORTED", "Streaming is not supported by this response writer", "", http.StatusInternalServerError)
 		return
 	}
-	service := newBriefInterviewService(req.BriefModel)
+	service := newBriefInterviewServiceForSession(session, req.BriefModel)
 	model := strings.TrimSpace(req.BriefModel)
 	stopHeartbeat := stream.StartHeartbeat(r.Context(), "follow_up", "", model, 10*time.Second)
 	defer stopHeartbeat()
@@ -763,11 +763,27 @@ func newID(prefix string) string {
 }
 
 func newBriefInterviewService(model string) *briefapp.InterviewService {
-	return briefapp.NewInterviewService(llmFollowUpGenerator{model: strings.TrimSpace(model)})
+	return newBriefInterviewServiceWithStyleGuide(model, "")
+}
+
+func newBriefInterviewServiceForSession(session briefdomain.ArticleBriefSession, model string) *briefapp.InterviewService {
+	_, guide, ok := workflowStore.GetProfileAndGuide(session.StyleProfileID)
+	if !ok {
+		return newBriefInterviewService(model)
+	}
+	return newBriefInterviewServiceWithStyleGuide(model, guide.Markdown)
+}
+
+func newBriefInterviewServiceWithStyleGuide(model, styleGuideMarkdown string) *briefapp.InterviewService {
+	return briefapp.NewInterviewService(llmFollowUpGenerator{
+		model:              strings.TrimSpace(model),
+		styleGuideMarkdown: strings.TrimSpace(styleGuideMarkdown),
+	})
 }
 
 type llmFollowUpGenerator struct {
-	model string
+	model              string
+	styleGuideMarkdown string
 }
 
 func (g llmFollowUpGenerator) GenerateFollowUp(ctx context.Context, session briefdomain.ArticleBriefSession, target briefdomain.ArticleQuestion, answer briefdomain.BriefAnswer, followUpIndex int) (string, error) {
@@ -780,7 +796,7 @@ func (g llmFollowUpGenerator) GenerateFollowUp(ctx context.Context, session brie
 	}
 	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
-	prompt := buildFollowUpPrompt(session, target, answer, followUpIndex)
+	prompt := buildFollowUpPrompt(session, target, answer, followUpIndex, g.styleGuideMarkdown)
 	generated, err := generator.Generate(ctx, prompt)
 	if err != nil {
 		return "", err
@@ -802,7 +818,7 @@ func (g llmFollowUpGenerator) GenerateFollowUpStream(ctx context.Context, sessio
 	}
 	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
-	prompt := buildFollowUpPrompt(session, target, answer, followUpIndex)
+	prompt := buildFollowUpPrompt(session, target, answer, followUpIndex, g.styleGuideMarkdown)
 	generated, err := generator.GenerateStream(ctx, prompt, onChunk)
 	if err != nil {
 		return "", err
@@ -856,8 +872,13 @@ func targetFieldForQuestion(value articleQuestionJSON) string {
 	return "custom"
 }
 
-func buildFollowUpPrompt(session briefdomain.ArticleBriefSession, target briefdomain.ArticleQuestion, answer briefdomain.BriefAnswer, followUpIndex int) string {
-	return fmt.Sprintf(`あなたはNote記事の取材編集者です。
+func buildFollowUpPrompt(session briefdomain.ArticleBriefSession, target briefdomain.ArticleQuestion, answer briefdomain.BriefAnswer, followUpIndex int, styleGuideMarkdown string) string {
+	excerpt := followUpPromptExcerpt(answer.Content, 90)
+	styleGuideMarkdown = strings.TrimSpace(styleGuideMarkdown)
+	if styleGuideMarkdown == "" {
+		styleGuideMarkdown = "文体ガイド未設定。セッションの既存回答に合わせ、自然な日本語で質問する。"
+	}
+	return fmt.Sprintf(`あなたは記事の取材編集者です。
 次の記事ブリーフ回答を深掘りするため、著者に聞く追加質問を1つだけ作ってください。
 
 条件:
@@ -865,24 +886,41 @@ func buildFollowUpPrompt(session briefdomain.ArticleBriefSession, target briefdo
 - はい/いいえで答えられる質問にしない
 - 選択式にしない
 - 具体的な経験、感情、判断、失敗、価値観のどれかを引き出す
+- 文体ガイドのトーンから外れない
 - 質問文だけを出力する
+- 質問は必ず「%s」というご回答を踏まえて、から始める
 
 セッションID: %s
-対象質問: %s
-回答: %s
+親質問: %s
+親回答: %s
 深掘り回数: %d
-`, session.ID, target.Text, answer.Content, followUpIndex)
+文体ガイド:
+%s
+`, excerpt, session.ID, target.Text, answer.Content, followUpIndex, styleGuideMarkdown)
 }
 
 func extractFollowUpQuestion(value string) string {
 	value = strings.TrimSpace(value)
-	value = strings.Trim(value, "`\"'「」")
+	value = strings.Trim(value, "`\"'")
 	for _, line := range strings.Split(value, "\n") {
 		line = strings.TrimSpace(strings.Trim(line, "-*0123456789. "))
-		line = strings.Trim(line, "\"'「」")
+		line = strings.Trim(line, "\"'")
 		if strings.HasSuffix(line, "？") || strings.HasSuffix(line, "?") {
 			return line
 		}
 	}
 	return value
+}
+
+func followUpPromptExcerpt(content string, maxRunes int) string {
+	content = strings.Join(strings.Fields(strings.TrimSpace(content)), " ")
+	if content == "" {
+		return "その点"
+	}
+	content = strings.Trim(content, "「」\"'")
+	runes := []rune(content)
+	if maxRunes > 0 && len(runes) > maxRunes {
+		return string(runes[:maxRunes-1]) + "..."
+	}
+	return content
 }

--- a/internal/handlers/workflow_followup_test.go
+++ b/internal/handlers/workflow_followup_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+)
+
+func TestBuildFollowUpPromptIncludesParentContextAndStyleGuide(t *testing.T) {
+	session, err := briefdomain.NewArticleBriefSession("session-1", "style-1")
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	target := briefdomain.FixedQuestions()[1]
+	answer := briefdomain.BriefAnswer{
+		QuestionID: target.ID,
+		Content:    "会社ブログとして、社員に実装判断の背景まで共有したい",
+		FlowType:   briefdomain.QuestionFlowMain,
+	}
+	prompt := buildFollowUpPrompt(session, target, answer, 1, "- 断定口調\n- 技術知見とビジョン共有を重視")
+
+	for _, want := range []string{
+		"親質問: " + target.Text,
+		"親回答: 会社ブログとして、社員に実装判断の背景まで共有したい",
+		"文体ガイド:",
+		"- 技術知見とビジョン共有を重視",
+		"質問は必ず「会社ブログとして、社員に実装判断の背景まで共有したい」というご回答を踏まえて、から始める",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestExtractFollowUpQuestionKeepsQuotedRationale(t *testing.T) {
+	generated := "承知しました。\n- 「社員に実装判断の背景まで共有したい」というご回答を踏まえて、どの判断を最初に説明しますか？\n"
+	got := extractFollowUpQuestion(generated)
+	want := "「社員に実装判断の背景まで共有したい」というご回答を踏まえて、どの判断を最初に説明しますか？"
+	if got != want {
+		t.Fatalf("question = %q, want %q", got, want)
+	}
+	if !briefdomain.IsAllowedFollowUpQuestion(got) {
+		t.Fatalf("extracted contextual question should be allowed: %q", got)
+	}
+}

--- a/internal/infrastructure/llamacpp/client.go
+++ b/internal/infrastructure/llamacpp/client.go
@@ -240,7 +240,7 @@ func (c *Client) GenerateWithSystem(ctx context.Context, systemPrompt, prompt st
 
 	var response chatCompletionResponse
 	if err := c.post(ctx, "/chat/completions", body, &response); err != nil {
-		if c.fallback != nil {
+		if c.fallback != nil && ctx.Err() == nil {
 			return c.fallback.GenerateWithSystem(ctx, systemPrompt, prompt)
 		}
 		return "", err
@@ -267,7 +267,7 @@ func (c *Client) GenerateWithSystem(ctx context.Context, systemPrompt, prompt st
 func (c *Client) GenerateStream(ctx context.Context, prompt string, onChunk func(string) error) (string, error) {
 	content, err := c.generateStream(ctx, prompt, onChunk)
 	if err != nil {
-		if c.fallback != nil && strings.TrimSpace(content) == "" {
+		if c.fallback != nil && strings.TrimSpace(content) == "" && ctx.Err() == nil {
 			if streamingFallback, ok := any(c.fallback).(interface {
 				GenerateStream(context.Context, string, func(string) error) (string, error)
 			}); ok {
@@ -381,7 +381,7 @@ func (c *Client) ListModels(ctx context.Context) ([]string, error) {
 	}
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		if c.fallback != nil {
+		if c.fallback != nil && ctx.Err() == nil {
 			return c.fallback.ListModels(ctx)
 		}
 		return nil, fmt.Errorf("list llama.cpp models: %w", err)

--- a/internal/infrastructure/llamacpp/client_test.go
+++ b/internal/infrastructure/llamacpp/client_test.go
@@ -213,6 +213,38 @@ func TestGenerateUsesFallbackClientWhenPrimaryFails(t *testing.T) {
 	}
 }
 
+func TestGenerateDoesNotFallbackAfterContextDeadline(t *testing.T) {
+	primaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"# Too Late"}}]}`))
+	}))
+	defer primaryServer.Close()
+	fallbackCalled := false
+	fallbackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"# Fallback Draft"}}]}`))
+	}))
+	defer fallbackServer.Close()
+
+	t.Setenv("LLM_BASE_URL", primaryServer.URL+"/v1")
+	t.Setenv("LLM_MODEL", "remote")
+	t.Setenv("FALLBACK_LLM_BASE_URL", fallbackServer.URL+"/v1")
+	t.Setenv("FALLBACK_LLM_MODEL", "fallback")
+
+	client, err := NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	if _, err := client.Generate(ctx, "write"); err == nil {
+		t.Fatal("expected deadline error")
+	}
+	if fallbackCalled {
+		t.Fatal("fallback should not be called after context deadline")
+	}
+}
+
 func TestGenerateUsesOrderedFallbackChain(t *testing.T) {
 	firstFallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "first fallback unavailable", http.StatusServiceUnavailable)

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -581,7 +581,7 @@ document.addEventListener('DOMContentLoaded', () => {
     context.className = 'parent-context';
     const parentQuestion = state.questionTextById[targetQuestionId] || targetQuestionId;
     const parentContent = answerValue(parentAnswer, 'content', 'Content') || '';
-    context.textContent = `${parentQuestion}: ${truncate(parentContent, 140)}`;
+    context.textContent = `深掘りの根拠 - ${parentQuestion}: ${truncate(parentContent, 140)}`;
     return context;
   }
 


### PR DESCRIPTION
## Summary
- Include parent question, parent answer, and active style guide context in deep-dive follow-up prompts.
- Prefix rule-based fallback follow-ups with the parent-answer quote and keep validation strict by stripping the rationale before yes/no checks.
- Label the parent answer rationale in the transcript UI.
- Improve scenario metrics so failed draft runs still print score/runes/verification, and avoid fallback after an expired context.
- Add Issue 20 validation notes for the cor_blog + markdown_blog Evo X2 run.

## Validation
- go test ./...
- node --check static/js/script.js
- git diff --check
- Local server smoke: http://127.0.0.1:8092/ and /api/formats
- Evo X2 scenario datapoint: cor_blog + markdown_blog, draft-only rerun: elapsed 439.86s, first_chunk_ms 31573, chunks 1778, runes 3675, score 72.3, final verification PASS, base URL http://evo-x2.tailb30e58.ts.net/v1

Closes #20