### PR TITLE
Implement editable draft section regeneration for #19

### DIFF
--- a/cmd/scenario/section_regeneration/main.go
+++ b/cmd/scenario/section_regeneration/main.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	draftapp "github.com/teradakousuke/note_maker/internal/application/draft"
+	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
+	authordomain "github.com/teradakousuke/note_maker/internal/domain/author"
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
+	"github.com/teradakousuke/note_maker/internal/infrastructure/llamacpp"
+)
+
+const defaultOutputDir = "tmp/section_regeneration"
+
+func main() {
+	if os.Getenv("RUN_LOCAL_LLM_SCENARIO") != "1" {
+		fatalf("set RUN_LOCAL_LLM_SCENARIO=1 to run local LLM section-regeneration scenario")
+	}
+
+	outputDir := envOrDefault("SCENARIO_OUTPUT_DIR", defaultOutputDir)
+	profilePath := envOrDefault("AUTHOR_PROFILE_PATH", "tmp/author_style/profile.json")
+	guidePath := envOrDefault("WRITING_GUIDE_PATH", "tmp/author_style/guide.json")
+	briefPath := envOrDefault("ARTICLE_BRIEF_PATH", "tmp/brief_interview/brief.json")
+	draftPath := envOrDefault("DRAFT_MARKDOWN_PATH", "tmp/draft_generation_issue20/draft.md")
+	sectionAnchor := envOrDefault("SCENARIO_SECTION_ANCHOR", "実装と検証")
+	baseURL := envFirst("http://127.0.0.1:8081/v1", "LLM_BASE_URL", "LLAMACPP_BASE_URL")
+	model := envFirst("gemma4:31b", "DRAFT_LLM_MODEL", "LLM_MODEL", "LLAMACPP_MODEL")
+	verifyModel := envFirst("gemma4:latest", "VERIFY_LLM_MODEL", "LLM_MODEL", "LLAMACPP_MODEL")
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		fatalf("create output dir: %v", err)
+	}
+
+	var profile authordomain.AuthorStyleProfile
+	var guide authordomain.WritingStyleGuide
+	var brief briefdomain.ArticleBrief
+	readJSON(profilePath, &profile)
+	readJSON(guidePath, &guide)
+	readJSON(briefPath, &brief)
+	draftMarkdown := readFile(draftPath)
+
+	persona, ok := personadomain.DefaultRegistry().Get(brief.PersonaID)
+	if !ok {
+		fatalf("persona %q not found", brief.PersonaID)
+	}
+	format, ok := outputformat.DefaultRegistry().Get(brief.OutputFormatID)
+	if !ok {
+		fatalf("output format %q not found", brief.OutputFormatID)
+	}
+	target, err := draftapp.FindMarkdownSection(draftMarkdown, sectionAnchor)
+	if err != nil {
+		fatalf("find target section: %v", err)
+	}
+
+	generator, err := llamacpp.NewClientFromEnvForPurpose("DRAFT")
+	if err != nil {
+		fatalf("create draft llm client: %v", err)
+	}
+	verifyClient, err := llamacpp.NewClientFromEnvForPurpose("VERIFY")
+	if err != nil {
+		fatalf("create verification llm client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), scenarioTimeout())
+	defer cancel()
+	started := time.Now()
+	result, err := draftapp.NewService(generator).RegenerateSection(ctx, draftapp.RegenerateSectionRequest{
+		GenerateRequest: draftapp.GenerateRequest{
+			StyleGuide:    guide,
+			Brief:         brief,
+			AuthorProfile: profile,
+			Persona:       persona,
+			OutputFormat:  format,
+		},
+		DraftMarkdown: draftMarkdown,
+		SectionAnchor: sectionAnchor,
+	})
+	elapsed := time.Since(started)
+	if err != nil {
+		fatalf("regenerate section: %v", err)
+	}
+
+	updatedDraft, err := articledomain.NewDraftForFormat(result.UpdatedDraftMarkdown, format.ID)
+	if err != nil {
+		fatalf("validate updated draft: %v", err)
+	}
+	evaluation := draftapp.EvaluateStyle(profile, brief, updatedDraft)
+	verifyStarted := time.Now()
+	verification, err := draftapp.NewLightweightVerifier(verifyClient).VerifyDraft(ctx, draftapp.VerificationRequest{
+		StyleGuide:    guide,
+		Brief:         brief,
+		AuthorProfile: profile,
+		Persona:       persona,
+		OutputFormat:  format,
+		DraftMarkdown: updatedDraft.Markdown(),
+		Evaluation:    evaluation,
+	})
+	verificationElapsed := time.Since(verifyStarted)
+	if err != nil {
+		fatalf("verify updated draft: %v", err)
+	}
+	verification.Performed = true
+
+	unchangedPrefix := strings.HasPrefix(result.UpdatedDraftMarkdown, draftMarkdown[:target.Start])
+	unchangedSuffix := strings.HasSuffix(result.UpdatedDraftMarkdown, draftMarkdown[target.End:])
+	writeFile(filepath.Join(outputDir, "replacement.md"), result.ReplacementMarkdown+"\n")
+	writeFile(filepath.Join(outputDir, "updated_draft.md"), result.UpdatedDraftMarkdown)
+	writeJSON(filepath.Join(outputDir, "section.json"), result.Section)
+	writeJSON(filepath.Join(outputDir, "evaluation.json"), evaluation)
+	writeJSON(filepath.Join(outputDir, "verification.json"), verification)
+
+	fmt.Printf("section regeneration scenario completed\n")
+	fmt.Printf("section_anchor=%s\n", sectionAnchor)
+	fmt.Printf("target_heading=%s\n", target.Heading)
+	fmt.Printf("persona_id=%s\n", persona.ID)
+	fmt.Printf("output_format_id=%s\n", format.ID)
+	fmt.Printf("elapsed_seconds=%.2f\n", elapsed.Seconds())
+	fmt.Printf("verification_elapsed_seconds=%.2f\n", verificationElapsed.Seconds())
+	fmt.Printf("updated_runes=%d\n", len([]rune(result.UpdatedDraftMarkdown)))
+	fmt.Printf("replacement_runes=%d\n", len([]rune(result.ReplacementMarkdown)))
+	fmt.Printf("score=%.1f\n", evaluation.Comparison.Score)
+	fmt.Printf("evaluation_passed=%v\n", evaluation.Passed)
+	fmt.Printf("verification_passed=%v\n", verification.Passed)
+	fmt.Printf("verification_summary=%s\n", verification.Summary)
+	fmt.Printf("unchanged_prefix=%v\n", unchangedPrefix)
+	fmt.Printf("unchanged_suffix=%v\n", unchangedSuffix)
+	fmt.Printf("llm_base_url=%s\n", baseURL)
+	fmt.Printf("llm_model=%s\n", model)
+	fmt.Printf("verify_model=%s\n", verifyModel)
+	fmt.Printf("replacement=%s\n", filepath.Join(outputDir, "replacement.md"))
+	fmt.Printf("updated_draft=%s\n", filepath.Join(outputDir, "updated_draft.md"))
+	if !unchangedPrefix || !unchangedSuffix {
+		fatalf("non-target draft bytes were changed")
+	}
+}
+
+func readJSON(path string, out any) {
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(encoded, out); err != nil {
+		fatalf("decode %s: %v", path, err)
+	}
+}
+
+func readFile(path string) string {
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		fatalf("read %s: %v", path, err)
+	}
+	return string(encoded)
+}
+
+func writeJSON(path string, value any) {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		fatalf("encode %s: %v", err)
+	}
+	writeFile(path, string(encoded)+"\n")
+}
+
+func writeFile(path, content string) {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		fatalf("write %s: %v", path, err)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envFirst(fallback string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return fallback
+}
+
+func envInt(key string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func scenarioTimeout() time.Duration {
+	seconds := envInt("SCENARIO_SECTION_TIMEOUT_SECONDS", 420)
+	return time.Duration(seconds) * time.Second
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,6 +43,7 @@ func main() {
 	r.HandleFunc("/api/brief-sessions/{id}/answers/{answer_id}/edit", handlers.EditBriefAnswerHandler).Methods("POST")
 	r.HandleFunc("/api/sessions/{id}/answers/{answer_id}/edit", handlers.EditBriefAnswerHandler).Methods("POST")
 	r.HandleFunc("/api/drafts", handlers.GenerateDraftHandler).Methods("POST")
+	r.HandleFunc("/api/drafts/{id}/regenerate-section", handlers.RegenerateDraftSectionHandler).Methods("POST")
 
 	// ルートパスへのアクセスはindex.htmlにリダイレクト
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -206,13 +206,13 @@ Current implementation status as of 2026-05-02:
 - Runtime validation showed that Tailnet inference can take 20+ minutes and still miss quality gates because of generation variance. Therefore, Phase A started with streaming and cancellation ([#18](https://github.com/terisuke/note_maker/issues/18)) before the broader transcript rewrite ([#17](https://github.com/terisuke/note_maker/issues/17)). Primary-runtime quality stabilization is tracked separately in [#40](https://github.com/terisuke/note_maker/issues/40).
 - Phase A2 is implemented and merged: `llamacpp.Client.GenerateStream`, streaming follow-up/draft service paths, `Accept: text/event-stream` handlers, browser Cancel controls, heartbeat events, and final runtime metrics ([#18](https://github.com/terisuke/note_maker/issues/18)).
 - Phase A1 is implemented and merged: the interview surface now renders a chat-style transcript, answer bubbles can be edited inline, and edits create child sessions via fork-on-edit while retaining `parent_session_id` lineage ([#17](https://github.com/terisuke/note_maker/issues/17)).
-- Phase A4 is implemented in code: follow-up prompts include parent question, parent answer, and active style guide context; rule-based fallback questions use the same quoted parent-answer prefix; the transcript labels the parent answer as the deep-dive rationale ([#20](https://github.com/terisuke/note_maker/issues/20)). Validation is recorded in [Issue 20 deep-dive rationale validation](../validation/issue-20-deep-dive-rationale-2026-05-02.md).
+- Phase A4 is implemented and merged: follow-up prompts include parent question, parent answer, and active style guide context; rule-based fallback questions use the same quoted parent-answer prefix; the transcript labels the parent answer as the deep-dive rationale ([#20](https://github.com/terisuke/note_maker/issues/20)). Validation is recorded in [Issue 20 deep-dive rationale validation](../validation/issue-20-deep-dive-rationale-2026-05-02.md).
+- Phase A3 is implemented in code: the generated Markdown textarea is editable, preview rendering live-syncs through `marked`, both preview and Markdown tabs can copy content, and `POST /api/drafts/{id}/regenerate-section` rewrites exactly one `## ` subtree while preserving the rest of the draft byte-for-byte ([#19](https://github.com/terisuke/note_maker/issues/19)). Validation is recorded in [Issue 19 section regeneration validation](../validation/issue-19-section-regeneration-2026-05-02.md).
 
 Near-term execution order:
 
-1. Merge [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale display inside the transcript.
-2. [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate once streamed drafts are visible and cancellable.
-3. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts.
+1. Merge [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate on top of the streamed draft surface.
+2. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts and section-regeneration candidates can become versioned draft records.
 
 ## Tracked issues
 

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -92,6 +92,9 @@ Acceptance:
 
 - Editing the textarea immediately updates the preview.
 - Regenerating section "## 実装" replaces only that subtree of the Markdown; the other sections remain byte-identical.
+- Regenerated candidates are shown as a text-only preview with accept/reject controls; accepting can still be manually edited before insertion.
+
+Implementation note as of 2026-05-02: #19 is implemented in code. The Phase A route uses the existing `session_id` as the draft identifier until Phase C adds versioned draft records. The canonical endpoint is `POST /api/drafts/{id}/regenerate-section`; it loads the stored style guide and brief, applies the current persona/output-format strategy, rejects replacement candidates containing multiple `## ` sections, and returns both the candidate section and the full updated draft. Evo X2 validation regenerated the company-blog `## 実装と検証：再現性の数値化` section in `167.33s`, then completed lightweight verification in `23.14s`; non-target prefix/suffix preservation was true and the score stayed in the prior company-blog band (`72.1` vs `72.3`). Details are in [Issue 19 section regeneration validation](../validation/issue-19-section-regeneration-2026-05-02.md).
 
 ### A4 — Deep-dive rationale surfaced
 
@@ -313,4 +316,4 @@ Draft generation now includes a lightweight final verification pass before retur
 
 ## Immediate next implementation step
 
-Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. [#18](https://github.com/terisuke/note_maker/issues/18) and [#17](https://github.com/terisuke/note_maker/issues/17) are merged. [#20](https://github.com/terisuke/note_maker/issues/20) is implemented in code; after merging it, continue with [#19](https://github.com/terisuke/note_maker/issues/19) for editable drafts and per-section regeneration.
+Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. [#18](https://github.com/terisuke/note_maker/issues/18), [#17](https://github.com/terisuke/note_maker/issues/17), and [#20](https://github.com/terisuke/note_maker/issues/20) are merged. [#19](https://github.com/terisuke/note_maker/issues/19) is implemented in code; after merging it, continue with Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) so editable draft state and regeneration history survive restarts.

--- a/docs/implementation-plans/next-implementation-cut.md
+++ b/docs/implementation-plans/next-implementation-cut.md
@@ -9,12 +9,15 @@ This document translates the current open issue set into the next executable imp
 Closed and incorporated:
 
 - [#11](https://github.com/terisuke/note_maker/issues/11) — strict Terisuke style tuning.
+- [#18](https://github.com/terisuke/note_maker/issues/18) — SSE streaming and cancellation.
+- [#17](https://github.com/terisuke/note_maker/issues/17) — chat transcript and editable answers.
+- [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale in transcript.
 - [#21](https://github.com/terisuke/note_maker/issues/21) — Persona and OutputFormat domain concepts.
 - [#38](https://github.com/terisuke/note_maker/issues/38) — Evo X2 Tailnet OpenAI-compatible API as primary runtime.
 
 Open and active:
 
-- Phase A: [#17](https://github.com/terisuke/note_maker/issues/17), [#18](https://github.com/terisuke/note_maker/issues/18), [#19](https://github.com/terisuke/note_maker/issues/19), [#20](https://github.com/terisuke/note_maker/issues/20).
+- Phase A: [#19](https://github.com/terisuke/note_maker/issues/19).
 - Phase B remaining: [#22](https://github.com/terisuke/note_maker/issues/22), [#23](https://github.com/terisuke/note_maker/issues/23), [#24](https://github.com/terisuke/note_maker/issues/24), [#25](https://github.com/terisuke/note_maker/issues/25).
 - Phase C: [#26](https://github.com/terisuke/note_maker/issues/26), [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28), extending [#14](https://github.com/terisuke/note_maker/issues/14).
 - Quality and packaging: [#13](https://github.com/terisuke/note_maker/issues/13), [#15](https://github.com/terisuke/note_maker/issues/15), [#29](https://github.com/terisuke/note_maker/issues/29), [#36](https://github.com/terisuke/note_maker/issues/36).
@@ -22,7 +25,7 @@ Open and active:
 
 ## Next target
 
-The ordering correction is now applied: [#18](https://github.com/terisuke/note_maker/issues/18) landed first, then [#17](https://github.com/terisuke/note_maker/issues/17) is being implemented on top of those streaming primitives.
+The ordering correction is now applied: [#18](https://github.com/terisuke/note_maker/issues/18), [#17](https://github.com/terisuke/note_maker/issues/17), and [#20](https://github.com/terisuke/note_maker/issues/20) have landed. [#19](https://github.com/terisuke/note_maker/issues/19) is the final Phase A UX cut before Phase C persistence.
 
 Reason: a real Tailnet Evo X2 scenario reached the correct endpoint but took `1396.80s` and still missed quality gates. A spinner-only UI is not usable at that latency. Streaming, heartbeat, cancellation, and partial-result retention are the highest-leverage improvement before reshaping the transcript.
 
@@ -39,16 +42,18 @@ Reason: a real Tailnet Evo X2 scenario reached the correct endpoint but took `13
    - Replace the bounded log with a transcript surface.
    - Render existing fixed and deep-dive answers as bubbles.
    - Add in-memory fork-on-edit endpoint first; persistence follows in Phase C.
-   - Status: implemented in code; merge before moving to #20.
+   - Status: implemented and merged.
 
 3. **[#20] Deep-dive rationale in transcript**
    - Add parent-answer excerpts to prompt and UI.
    - Ensure LLM and rule-based fallback paths produce the same contextual prefix.
+   - Status: implemented and merged.
 
 4. **[#19] Editable draft and section regenerate**
    - Make the Markdown draft editable after streaming lands.
    - Add section anchor parsing and replacement tests.
    - Regenerate one heading subtree at a time.
+   - Status: implemented in code; merge before moving to #26.
 
 5. **[#26] SQLite persistence**
    - Persist answer forks, draft versions, guide versions, and project/article history.

--- a/docs/validation/issue-19-section-regeneration-2026-05-02.md
+++ b/docs/validation/issue-19-section-regeneration-2026-05-02.md
@@ -1,0 +1,63 @@
+# Issue 19 section regeneration validation
+
+Date: 2026-05-02
+
+## Scope
+
+Validate [#19](https://github.com/terisuke/note_maker/issues/19): editable draft Markdown plus one-section regeneration.
+
+The runtime scenario used the prior Phase A4 company-blog draft so this run differs from the earlier note-style runs while still measuring the same Evo X2 Tailnet primary path.
+
+## Runtime
+
+- Base URL: `http://evo-x2.tailb30e58.ts.net/v1`
+- Draft model: `gemma4:31b`
+- Verification model: `gemma4:latest`
+- Persona: `terisuke`
+- Output format: `markdown_blog`
+- Source draft: `tmp/draft_generation_issue20/draft.md`
+- Target section: `## 実装と検証：再現性の数値化`
+- Output directory: `tmp/section_regeneration_issue19`
+
+## Results
+
+| Metric | Value |
+|---|---:|
+| Section regeneration elapsed | 167.33s |
+| Lightweight verification elapsed | 23.14s |
+| Updated draft length | 4011 runes |
+| Replacement length | 1336 runes |
+| Style score | 72.1 |
+| Lightweight verification | PASS |
+| Non-target prefix unchanged | true |
+| Non-target suffix unchanged | true |
+
+Comparison to Issue 20 company-blog draft run:
+
+| Run | Elapsed | Runes | Score | Verification |
+|---|---:|---:|---:|---|
+| Issue 20 full draft | 439.86s | 3675 | 72.3 | PASS |
+| Issue 19 section regenerate | 167.33s + 23.14s verify | 4011 | 72.1 | PASS |
+
+## Observations
+
+- The section replacement preserved every byte before and after the target `## ` subtree.
+- The score stayed in the same band as the previous company-blog run (`72.1` vs `72.3`), which supports treating this as medium/style variance rather than a #19 regression.
+- The strict Terisuke note-style threshold still fails for company-blog drafts because paragraph and sentence lengths are longer than the note baseline. This remains a cross-medium baseline issue, not a section-regeneration bug.
+- The first scenario attempt used a shortened anchor (`実装と検証`) and correctly failed because anchors require the exact heading/normalized anchor.
+- A second attempt used the correct heading but hit the client default `LLM_TIMEOUT_SECONDS=180` before Evo X2 returned response headers. The successful run set both the scenario timeout and LLM client timeout to 600 seconds.
+- The lightweight verifier summary contains a typo (`Tailsale互換API`). The verifier still returned PASS, so this is recorded as a quality signal for future verifier-prompt tightening rather than a blocker for #19.
+
+## Commands
+
+```bash
+RUN_LOCAL_LLM_SCENARIO=1 \
+LLM_BASE_URL=http://evo-x2.tailb30e58.ts.net/v1 \
+LLM_TIMEOUT_SECONDS=600 \
+DRAFT_LLM_MODEL=gemma4:31b \
+VERIFY_LLM_MODEL=gemma4:latest \
+SCENARIO_OUTPUT_DIR=tmp/section_regeneration_issue19 \
+SCENARIO_SECTION_ANCHOR=実装と検証：再現性の数値化 \
+SCENARIO_SECTION_TIMEOUT_SECONDS=600 \
+go run ./cmd/scenario/section_regeneration
+```

--- a/internal/application/draft/prompt.go
+++ b/internal/application/draft/prompt.go
@@ -114,6 +114,63 @@ func BuildStyleRevisionPrompt(originalPrompt, draftMarkdown string, evaluation S
 	return prompt.String()
 }
 
+// BuildSectionRegenerationPrompt asks for one replacement section only.
+func BuildSectionRegenerationPrompt(guide WritingStyleGuide, brief ArticleBrief, profile AuthorStyleProfile, persona personadomain.Persona, format outputformat.OutputFormat, draftMarkdown string, section MarkdownSection) string {
+	var prompt strings.Builder
+	prompt.WriteString("あなたは日本語記事の編集者です。既存下書きの指定された1セクションだけを書き直してください。\n")
+	prompt.WriteString("前置き、解説、内部メモは出力しないでください。返すのは置換後のセクション本文だけです。\n")
+	prompt.WriteString("必ず同じ `## ` 見出しで始め、次の `## ` セクションや記事全体は出力しないでください。\n\n")
+
+	prompt.WriteString("## 書き分けモード\n")
+	appendLine(&prompt, "Persona", persona.ID+" / "+persona.DisplayName)
+	appendLine(&prompt, "OutputFormat", format.ID+" / "+format.DisplayName)
+	appendLine(&prompt, "媒体ルール", format.PromptFragment)
+	appendLine(&prompt, "人格メモ", persona.PromptHint())
+	prompt.WriteString("\n")
+
+	if guideMarkdown := formatGuideMarkdown(format.ID); guideMarkdown != "" {
+		prompt.WriteString("## 媒体別Markdownガイド\n")
+		prompt.WriteString(guideMarkdown)
+		prompt.WriteString("\n\n")
+	}
+
+	prompt.WriteString("## 文体ガイド\n")
+	prompt.WriteString(truncateRunes(formatStyleGuide(guide), 1800))
+	prompt.WriteString("\n\n")
+
+	prompt.WriteString("## 記事ブリーフ\n")
+	appendLine(&prompt, "テーマ", brief.Theme)
+	appendLine(&prompt, "読者", brief.Reader)
+	appendLine(&prompt, "必ず含めること", brief.MustInclude)
+	appendLine(&prompt, "著者本人の属人的な文脈", brief.PersonalContext)
+	appendLine(&prompt, "含めないこと", brief.Exclusions)
+	appendLine(&prompt, "トーンと立場", brief.ToneStance)
+	appendDeepDives(&prompt, brief.DeepDives)
+	if calibration := strictMetricCalibration(profile, brief, guide); calibration != "" {
+		prompt.WriteString("\n## strict style calibration\n")
+		prompt.WriteString(calibration)
+		prompt.WriteString("\n")
+	}
+
+	prompt.WriteString("\n## 現在の全体下書き（構成参照用）\n")
+	prompt.WriteString(truncateRunes(draftMarkdown, 5000))
+	prompt.WriteString("\n\n")
+
+	prompt.WriteString("## 置換対象セクション\n")
+	appendLine(&prompt, "section_anchor", section.Anchor)
+	appendLine(&prompt, "heading", section.Heading)
+	prompt.WriteString(section.Content)
+	prompt.WriteString("\n\n")
+
+	prompt.WriteString("## 出力条件\n")
+	prompt.WriteString("1. 出力は `## " + section.Heading + "` から始める。\n")
+	prompt.WriteString("2. 他の `## ` セクション、frontmatter、記事タイトル、全体下書きは出力しない。\n")
+	prompt.WriteString("3. 既存セクションより具体性、根拠、読みやすさを上げる。\n")
+	prompt.WriteString("4. 媒体ルール、人格メモ、文体ガイド、記事ブリーフを守る。\n")
+	prompt.WriteString("5. コード例を使う場合は媒体ルールに沿う。\n")
+	return prompt.String()
+}
+
 func revisionMetricDetail(evaluation StyleEvaluation) string {
 	var lines []string
 	ref := evaluation.Comparison.Reference

--- a/internal/application/draft/section.go
+++ b/internal/application/draft/section.go
@@ -1,0 +1,165 @@
+package draft
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
+)
+
+// MarkdownSection is one editable top-level article section headed by "## ".
+type MarkdownSection struct {
+	Anchor  string `json:"anchor"`
+	Heading string `json:"heading"`
+	Content string `json:"content"`
+	Start   int    `json:"start"`
+	End     int    `json:"end"`
+}
+
+// RegenerateSectionRequest asks the model to replace one section only.
+type RegenerateSectionRequest struct {
+	GenerateRequest
+	DraftMarkdown string
+	SectionAnchor string
+}
+
+// RegenerateSectionResult carries the replacement and the full updated draft.
+type RegenerateSectionResult struct {
+	Section              MarkdownSection `json:"section"`
+	ReplacementMarkdown  string          `json:"replacement_markdown"`
+	UpdatedDraftMarkdown string          `json:"updated_draft_markdown"`
+}
+
+// FindMarkdownSection finds a "## " section by exact heading or normalized anchor.
+func FindMarkdownSection(markdown, anchor string) (MarkdownSection, error) {
+	anchor = normalizeSectionAnchor(anchor)
+	if anchor == "" {
+		return MarkdownSection{}, fmt.Errorf("section anchor is required")
+	}
+	sections := MarkdownSections(markdown)
+	for _, section := range sections {
+		if normalizeSectionAnchor(section.Anchor) == anchor || normalizeSectionAnchor(section.Heading) == anchor {
+			return section, nil
+		}
+	}
+	return MarkdownSection{}, fmt.Errorf("section %q was not found", anchor)
+}
+
+// MarkdownSections returns all "## " sections, ending each before the next "## ".
+func MarkdownSections(markdown string) []MarkdownSection {
+	type heading struct {
+		offset int
+		line   string
+	}
+	var headings []heading
+	offset := 0
+	for _, line := range strings.SplitAfter(markdown, "\n") {
+		trimmed := strings.TrimSpace(strings.TrimSuffix(line, "\n"))
+		if strings.HasPrefix(trimmed, "## ") && !strings.HasPrefix(trimmed, "### ") {
+			headings = append(headings, heading{offset: offset, line: trimmed})
+		}
+		offset += len(line)
+	}
+	sections := make([]MarkdownSection, 0, len(headings))
+	for i, item := range headings {
+		end := len(markdown)
+		if i+1 < len(headings) {
+			end = headings[i+1].offset
+		}
+		headingText := strings.TrimSpace(strings.TrimPrefix(item.line, "## "))
+		sections = append(sections, MarkdownSection{
+			Anchor:  sectionAnchor(headingText),
+			Heading: headingText,
+			Content: markdown[item.offset:end],
+			Start:   item.offset,
+			End:     end,
+		})
+	}
+	return sections
+}
+
+// ReplaceMarkdownSection returns a full draft with only section's byte range replaced.
+func ReplaceMarkdownSection(markdown string, section MarkdownSection, replacement string) (string, error) {
+	if section.Start < 0 || section.End < section.Start || section.End > len(markdown) {
+		return "", fmt.Errorf("section range is invalid")
+	}
+	replacement = strings.TrimSpace(replacement)
+	if replacement == "" {
+		return "", fmt.Errorf("replacement section is empty")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(replacement), "## ") {
+		replacement = "## " + section.Heading + "\n\n" + replacement
+	}
+	if !strings.HasSuffix(replacement, "\n") {
+		replacement += "\n"
+	}
+	replacementSections := MarkdownSections(replacement)
+	if len(replacementSections) != 1 {
+		return "", fmt.Errorf("replacement must contain exactly one h2 section")
+	}
+	if normalizeSectionAnchor(replacementSections[0].Heading) != normalizeSectionAnchor(section.Heading) {
+		return "", fmt.Errorf("replacement heading %q does not match target heading %q", replacementSections[0].Heading, section.Heading)
+	}
+	return markdown[:section.Start] + replacement + markdown[section.End:], nil
+}
+
+// RegenerateSection rewrites one "## " section while preserving the rest byte-for-byte.
+func (s *Service) RegenerateSection(ctx context.Context, req RegenerateSectionRequest) (RegenerateSectionResult, error) {
+	if s.generator == nil {
+		return RegenerateSectionResult{}, fmt.Errorf("text generator is required")
+	}
+	if err := validateRequest(req.GenerateRequest); err != nil {
+		return RegenerateSectionResult{}, err
+	}
+	section, err := FindMarkdownSection(req.DraftMarkdown, req.SectionAnchor)
+	if err != nil {
+		return RegenerateSectionResult{}, err
+	}
+	persona := req.Persona
+	if persona.ID == "" {
+		persona, _ = personadomain.DefaultRegistry().Get(req.Brief.PersonaID)
+	}
+	format := req.OutputFormat
+	if format.ID == "" {
+		var ok bool
+		format, ok = outputformat.DefaultRegistry().Get(req.Brief.OutputFormatID)
+		if !ok {
+			format, _ = outputformat.DefaultRegistry().Get(outputformat.IDNoteArticle)
+		}
+	}
+	prompt := BuildSectionRegenerationPrompt(req.StyleGuide, req.Brief, req.AuthorProfile, persona, format, req.DraftMarkdown, section)
+	replacement, err := s.generator.Generate(ctx, prompt)
+	if err != nil {
+		return RegenerateSectionResult{}, fmt.Errorf("regenerate section with local llm: %w", err)
+	}
+	updated, err := ReplaceMarkdownSection(req.DraftMarkdown, section, replacement)
+	if err != nil {
+		return RegenerateSectionResult{}, err
+	}
+	if _, err := articledomain.NewDraftForFormat(updated, format.ID); err != nil {
+		return RegenerateSectionResult{}, fmt.Errorf("regenerated draft is invalid: %w", err)
+	}
+	return RegenerateSectionResult{
+		Section:              section,
+		ReplacementMarkdown:  strings.TrimSpace(replacement),
+		UpdatedDraftMarkdown: updated,
+	}, nil
+}
+
+func sectionAnchor(heading string) string {
+	return normalizeSectionAnchor(heading)
+}
+
+func normalizeSectionAnchor(value string) string {
+	value = strings.TrimSpace(strings.TrimPrefix(value, "## "))
+	value = strings.ToLower(value)
+	replacer := strings.NewReplacer(" ", "-", "　", "-", "_", "-", "/", "-", ":", "", "：", "", "?", "", "？", "", "!", "", "！", "", "`", "", "\"", "", "'", "")
+	value = replacer.Replace(value)
+	for strings.Contains(value, "--") {
+		value = strings.ReplaceAll(value, "--", "-")
+	}
+	return strings.Trim(value, "-")
+}

--- a/internal/application/draft/section_test.go
+++ b/internal/application/draft/section_test.go
@@ -1,0 +1,135 @@
+package draft
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
+	authordomain "github.com/teradakousuke/note_maker/internal/domain/author"
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
+)
+
+func TestFindMarkdownSectionByHeadingAndAnchor(t *testing.T) {
+	markdown := "# Title\n\nLead\n\n## 実装\n\nA\n\n### Detail\n\nB\n\n## 検証結果\n\nC\n"
+	section, err := FindMarkdownSection(markdown, "実装")
+	if err != nil {
+		t.Fatalf("find section: %v", err)
+	}
+	if section.Heading != "実装" {
+		t.Fatalf("heading = %q", section.Heading)
+	}
+	if !strings.Contains(section.Content, "### Detail") {
+		t.Fatalf("section should include nested headings: %q", section.Content)
+	}
+	if strings.Contains(section.Content, "## 検証結果") {
+		t.Fatalf("section should stop before next h2: %q", section.Content)
+	}
+	if _, err := FindMarkdownSection(markdown, "検証結果"); err != nil {
+		t.Fatalf("find by normalized anchor: %v", err)
+	}
+}
+
+func TestReplaceMarkdownSectionPreservesOtherSections(t *testing.T) {
+	markdown := "# Title\n\nIntro\n\n## 実装\n\nold\n\n## 検証\n\nkeep\n"
+	section, err := FindMarkdownSection(markdown, "実装")
+	if err != nil {
+		t.Fatalf("find section: %v", err)
+	}
+	updated, err := ReplaceMarkdownSection(markdown, section, "## 実装\n\nnew\n")
+	if err != nil {
+		t.Fatalf("replace section: %v", err)
+	}
+	want := "# Title\n\nIntro\n\n## 実装\n\nnew\n## 検証\n\nkeep\n"
+	if updated != want {
+		t.Fatalf("updated markdown:\n%q\nwant:\n%q", updated, want)
+	}
+}
+
+func TestReplaceMarkdownSectionRejectsMultipleH2Sections(t *testing.T) {
+	markdown := "# Title\n\n## 実装\n\nold\n\n## 検証\n\nkeep\n"
+	section, err := FindMarkdownSection(markdown, "実装")
+	if err != nil {
+		t.Fatalf("find section: %v", err)
+	}
+	_, err = ReplaceMarkdownSection(markdown, section, "## 実装\n\nnew\n\n## 検証\n\nrewritten")
+	if err == nil {
+		t.Fatal("expected multiple h2 replacement to fail")
+	}
+}
+
+func TestRegenerateSectionReplacesOnlyTargetSection(t *testing.T) {
+	markdown := "# Title\n\nIntro\n\n## 実装\n\nold\n\n## 検証\n\nkeep\n"
+	service := NewService(staticSectionGenerator{content: "## 実装\n\nnew content\n"})
+	result, err := service.RegenerateSection(context.Background(), RegenerateSectionRequest{
+		GenerateRequest: GenerateRequest{
+			StyleGuide: authordomain.WritingStyleGuide{
+				ID:                   "guide-1",
+				ProfileID:            "profile-1",
+				PreferredFirstPerson: "僕",
+				Markdown:             "- practical",
+				RecurringThemes:      []string{"AI"},
+				ParagraphRhythm:      "短め",
+				SentenceRhythm:       "明快",
+				HeadingGuidance:      "具体的",
+				QuoteGuidance:        "必要な引用だけ使う",
+				OpeningPatterns:      []string{"体験から始める"},
+				ConclusionPatterns:   []string{"次の行動で締める"},
+			},
+			Brief: briefdomain.ArticleBrief{
+				StyleProfileID:        "profile-1",
+				PersonaID:             personadomain.IDTerisuke,
+				OutputFormatID:        outputformat.IDNoteArticle,
+				Theme:                 "section regenerate",
+				Reader:                "writers",
+				MustInclude:           "implementation",
+				TargetLengthStructure: "1200字",
+			},
+			AuthorProfile: authordomain.AuthorStyleProfile{
+				ID:                   "profile-1",
+				Version:              "author-style/v1",
+				Source:               authordomain.AuthorSource{Articles: []authordomain.SourceArticle{{ID: "article-1"}}},
+				ArticleCount:         1,
+				PreferredFirstPerson: "僕",
+				Metrics: articledomain.StyleProfile{
+					CharCount:        1000,
+					ParagraphCount:   10,
+					SentenceCount:    20,
+					FirstPersonCount: 3,
+				},
+			},
+			Persona:      mustPersona(t, personadomain.IDTerisuke),
+			OutputFormat: outputformat.DefaultRegistry().MustGet(outputformat.IDNoteArticle),
+		},
+		DraftMarkdown: markdown,
+		SectionAnchor: "実装",
+	})
+	if err != nil {
+		t.Fatalf("regenerate section: %v", err)
+	}
+	if !strings.Contains(result.UpdatedDraftMarkdown, "## 実装\n\nnew content\n") {
+		t.Fatalf("replacement missing: %q", result.UpdatedDraftMarkdown)
+	}
+	if !strings.Contains(result.UpdatedDraftMarkdown, "## 検証\n\nkeep\n") {
+		t.Fatalf("non-target section changed: %q", result.UpdatedDraftMarkdown)
+	}
+}
+
+type staticSectionGenerator struct {
+	content string
+}
+
+func (g staticSectionGenerator) Generate(ctx context.Context, prompt string) (string, error) {
+	return g.content, nil
+}
+
+func mustPersona(t *testing.T, id string) personadomain.Persona {
+	t.Helper()
+	persona, ok := personadomain.DefaultRegistry().Get(id)
+	if !ok {
+		t.Fatalf("persona %q was not found", id)
+	}
+	return persona
+}

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -113,10 +113,26 @@ type generateDraftRequest struct {
 	VerifyModel    string `json:"verify_model"`
 }
 
+type regenerateDraftSectionRequest struct {
+	StyleProfileID string `json:"style_profile_id"`
+	SessionID      string `json:"session_id"`
+	PersonaID      string `json:"persona_id"`
+	OutputFormatID string `json:"output_format_id"`
+	DraftModel     string `json:"draft_model"`
+	DraftMarkdown  string `json:"draft_markdown"`
+	SectionAnchor  string `json:"section_anchor"`
+}
+
 type generateDraftResponse struct {
 	Draft        string                     `json:"draft"`
 	Evaluation   draftapp.StyleEvaluation   `json:"evaluation"`
 	Verification draftapp.FinalVerification `json:"verification"`
+}
+
+type regenerateDraftSectionResponse struct {
+	Section              draftapp.MarkdownSection `json:"section"`
+	ReplacementMarkdown  string                   `json:"replacement_markdown"`
+	UpdatedDraftMarkdown string                   `json:"updated_draft_markdown"`
 }
 
 // ListPersonasHandler returns built-in writing personas.
@@ -597,6 +613,90 @@ func streamGenerateDraft(w http.ResponseWriter, r *http.Request, req generateDra
 		Verification: result.Verification,
 	})
 	_ = stream.Send("done", streamStatus{Status: "completed", Phase: "draft", Endpoint: endpoint, Model: model, StartedAt: stream.started.Format(time.RFC3339), ElapsedMS: stream.ElapsedMS(), Runes: len([]rune(result.Draft.Markdown())), Score: result.Evaluation.Comparison.Score})
+}
+
+// RegenerateDraftSectionHandler rewrites only one h2 subtree of the current draft.
+func RegenerateDraftSectionHandler(w http.ResponseWriter, r *http.Request) {
+	var req regenerateDraftSectionRequest
+	if err := decodeJSONRequest(r, &req); err != nil {
+		respondWithError(w, "INVALID_REQUEST_FORMAT", "Invalid request body", "", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.SessionID) == "" {
+		req.SessionID = pathValue(r, "id")
+	}
+	profile, guide, articleBrief, persona, format, ok := draftContextFromRequest(req.StyleProfileID, req.SessionID, req.PersonaID, req.OutputFormatID)
+	if !ok {
+		respondWithError(w, "DRAFT_CONTEXT_NOT_FOUND", "Draft context was not found", "", http.StatusBadRequest)
+		return
+	}
+	generator, err := llamacpp.NewClientFromEnvForPurposeWithModel("DRAFT", req.DraftModel)
+	if err != nil {
+		respondWithError(w, "GENERATOR_INITIALIZATION_FAILED", "Failed to initialize local LLM client", err.Error(), http.StatusInternalServerError)
+		return
+	}
+	service := draftapp.NewService(generator)
+	result, err := service.RegenerateSection(r.Context(), draftapp.RegenerateSectionRequest{
+		GenerateRequest: draftapp.GenerateRequest{
+			StyleGuide:    guide,
+			Brief:         articleBrief,
+			AuthorProfile: profile,
+			Persona:       persona,
+			OutputFormat:  format,
+		},
+		DraftMarkdown: req.DraftMarkdown,
+		SectionAnchor: req.SectionAnchor,
+	})
+	if err != nil {
+		respondWithError(w, "DRAFT_SECTION_REGENERATE_FAILED", "Failed to regenerate draft section", err.Error(), http.StatusBadRequest)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, regenerateDraftSectionResponse{
+		Section:              result.Section,
+		ReplacementMarkdown:  result.ReplacementMarkdown,
+		UpdatedDraftMarkdown: result.UpdatedDraftMarkdown,
+	})
+}
+
+func draftContextFromRequest(styleProfileID, sessionID, personaID, formatID string) (authordomain.AuthorStyleProfile, authordomain.WritingStyleGuide, briefdomain.ArticleBrief, personadomain.Persona, outputformat.OutputFormat, bool) {
+	sessionID = strings.TrimSpace(sessionID)
+	if strings.TrimSpace(styleProfileID) == "" && sessionID != "" {
+		if session, ok := workflowStore.GetSession(sessionID); ok {
+			styleProfileID = session.StyleProfileID
+		}
+	}
+	profile, guide, ok := workflowStore.GetProfileAndGuide(styleProfileID)
+	if !ok {
+		return authordomain.AuthorStyleProfile{}, authordomain.WritingStyleGuide{}, briefdomain.ArticleBrief{}, personadomain.Persona{}, outputformat.OutputFormat{}, false
+	}
+	articleBrief, ok := workflowStore.GetBrief(sessionID)
+	if !ok {
+		session, sessionOK := workflowStore.GetSession(sessionID)
+		if !sessionOK || !session.Completed {
+			return authordomain.AuthorStyleProfile{}, authordomain.WritingStyleGuide{}, briefdomain.ArticleBrief{}, personadomain.Persona{}, outputformat.OutputFormat{}, false
+		}
+		articleBrief = session.AssembleBrief()
+	}
+	if strings.TrimSpace(personaID) == "" {
+		personaID = articleBrief.PersonaID
+	}
+	persona, ok := personadomain.DefaultRegistry().Get(personaID)
+	if !ok {
+		return authordomain.AuthorStyleProfile{}, authordomain.WritingStyleGuide{}, briefdomain.ArticleBrief{}, personadomain.Persona{}, outputformat.OutputFormat{}, false
+	}
+	if strings.TrimSpace(formatID) == "" {
+		formatID = articleBrief.OutputFormatID
+	}
+	if strings.TrimSpace(formatID) == "" {
+		formatID = persona.DefaultFormat
+	}
+	format, ok := outputformat.DefaultRegistry().Get(formatID)
+	if !ok {
+		return authordomain.AuthorStyleProfile{}, authordomain.WritingStyleGuide{}, briefdomain.ArticleBrief{}, personadomain.Persona{}, outputformat.OutputFormat{}, false
+	}
+	articleBrief.PersonaID = persona.ID
+	articleBrief.OutputFormatID = format.ID
+	return profile, guide, articleBrief, persona, format, true
 }
 
 func newDraftServiceWithVerifier(generator draftapp.TextGenerator, model string) (*draftapp.Service, error) {

--- a/internal/handlers/workflow_regenerate_section_test.go
+++ b/internal/handlers/workflow_regenerate_section_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
+	"github.com/teradakousuke/note_maker/internal/infrastructure/repository/memory"
+)
+
+func TestRegenerateDraftSectionHandlerReplacesOnlyTargetSection(t *testing.T) {
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"## 実装\n\n新しい実装内容です。"}}]}`))
+	}))
+	defer llmServer.Close()
+	t.Setenv("LLM_BASE_URL", llmServer.URL+"/v1")
+	t.Setenv("DRAFT_LLM_MODEL", "gemma4:31b")
+
+	workflowStore = memory.NewWorkflowStore()
+	persona, ok := personadomain.DefaultRegistry().Get(personadomain.IDTerisuke)
+	if !ok {
+		t.Fatal("missing terisuke persona")
+	}
+	style, err := buildPresetAuthorStyle(persona)
+	if err != nil {
+		t.Fatalf("build style: %v", err)
+	}
+	if err := workflowStore.SaveAuthorStyle(style); err != nil {
+		t.Fatalf("save style: %v", err)
+	}
+	if err := workflowStore.SaveBrief("session-1", briefdomain.ArticleBrief{
+		StyleProfileID:        style.Profile.ID,
+		PersonaID:             persona.ID,
+		OutputFormatID:        outputformat.IDNoteArticle,
+		Theme:                 "セクション再生成",
+		Reader:                "記事を書く人",
+		MustInclude:           "実装",
+		TargetLengthStructure: "1200字",
+	}); err != nil {
+		t.Fatalf("save brief: %v", err)
+	}
+
+	draft := "# Title\n\nIntro\n\n## 実装\n\n古い実装内容です。\n\n## 検証\n\nここは残します。\n"
+	body := `{"style_profile_id":"` + style.Profile.ID + `","session_id":"session-1","section_anchor":"実装","draft_markdown":` + quoteJSONString(draft) + `}`
+	request := httptest.NewRequest(http.MethodPost, "/api/drafts/session-1/regenerate-section", bytes.NewBufferString(body))
+	request = mux.SetURLVars(request, map[string]string{"id": "session-1"})
+	response := httptest.NewRecorder()
+
+	RegenerateDraftSectionHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var payload regenerateDraftSectionResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !strings.Contains(payload.UpdatedDraftMarkdown, "## 実装\n\n新しい実装内容です。") {
+		t.Fatalf("updated draft missing replacement:\n%s", payload.UpdatedDraftMarkdown)
+	}
+	if !strings.Contains(payload.UpdatedDraftMarkdown, "## 検証\n\nここは残します。") {
+		t.Fatalf("non-target section changed:\n%s", payload.UpdatedDraftMarkdown)
+	}
+	if strings.Contains(payload.UpdatedDraftMarkdown, "古い実装内容") {
+		t.Fatalf("old section remained:\n%s", payload.UpdatedDraftMarkdown)
+	}
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -433,6 +433,31 @@ pre {
     margin-bottom: 12px;
 }
 
+#copy-preview-btn {
+    margin-top: 12px;
+}
+
+.section-candidate {
+    display: grid;
+    gap: 10px;
+    margin-top: 14px;
+    padding: 14px;
+    border: 1px solid var(--line);
+    border-left: 4px solid var(--primary);
+    border-radius: 6px;
+    background: #f8fafc;
+}
+
+.section-candidate h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+#section-candidate-output {
+    min-height: 220px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
 .hidden {
     display: none !important;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -169,10 +169,23 @@
           </div>
           <div id="preview-tab" class="tab-pane active">
             <div id="preview-content"></div>
+            <button id="copy-preview-btn" class="secondary-btn" type="button">プレビューをコピー</button>
           </div>
           <div id="markdown-tab" class="tab-pane">
-            <textarea id="markdown-output" readonly></textarea>
-            <button id="copy-btn" class="secondary-btn">コピー</button>
+            <textarea id="markdown-output"></textarea>
+            <div class="button-row">
+              <button id="copy-btn" class="secondary-btn" type="button">Markdownをコピー</button>
+              <button id="regenerate-section-btn" class="secondary-btn" type="button" disabled>このセクションを再生成</button>
+            </div>
+            <div id="section-status" class="status-line"></div>
+            <div id="section-candidate" class="section-candidate hidden">
+              <h3>再生成候補</h3>
+              <textarea id="section-candidate-output" rows="10"></textarea>
+              <div class="button-row">
+                <button id="accept-section-btn" class="primary-btn" type="button">候補を反映</button>
+                <button id="reject-section-btn" class="secondary-btn" type="button">破棄</button>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     lastSubmittedAnswer: '',
     answerAbortController: null,
     draftAbortController: null,
+    pendingSectionReplacement: null,
   };
 
   const el = {
@@ -67,6 +68,13 @@ document.addEventListener('DOMContentLoaded', () => {
     previewContent: document.getElementById('preview-content'),
     markdownOutput: document.getElementById('markdown-output'),
     copy: document.getElementById('copy-btn'),
+    copyPreview: document.getElementById('copy-preview-btn'),
+    regenerateSection: document.getElementById('regenerate-section-btn'),
+    sectionStatus: document.getElementById('section-status'),
+    sectionCandidate: document.getElementById('section-candidate'),
+    sectionCandidateOutput: document.getElementById('section-candidate-output'),
+    acceptSection: document.getElementById('accept-section-btn'),
+    rejectSection: document.getElementById('reject-section-btn'),
     loading: document.getElementById('loading'),
     loadingText: document.getElementById('loading-text'),
     errorArea: document.getElementById('error-message-area'),
@@ -94,6 +102,14 @@ document.addEventListener('DOMContentLoaded', () => {
   el.generateDraft.addEventListener('click', generateDraft);
   el.cancelDraft.addEventListener('click', () => state.draftAbortController?.abort());
   el.copy.addEventListener('click', copyMarkdown);
+  el.copyPreview.addEventListener('click', copyPreviewText);
+  el.markdownOutput.addEventListener('input', syncDraftEditor);
+  el.markdownOutput.addEventListener('keyup', updateSectionControls);
+  el.markdownOutput.addEventListener('click', updateSectionControls);
+  el.markdownOutput.addEventListener('select', updateSectionControls);
+  el.regenerateSection.addEventListener('click', regenerateCurrentSection);
+  el.acceptSection.addEventListener('click', acceptSectionCandidate);
+  el.rejectSection.addEventListener('click', rejectSectionCandidate);
 
   document.querySelectorAll('.tab-btn').forEach((button) => {
     button.addEventListener('click', () => setActiveTab(button.dataset.tab));
@@ -329,6 +345,8 @@ document.addEventListener('DOMContentLoaded', () => {
     el.previewContent.innerHTML = '';
     el.evaluationSummary.textContent = '';
     el.verificationSummary.textContent = '';
+    el.sectionStatus.textContent = '';
+    rejectSectionCandidate();
     el.draftResult.classList.remove('hidden');
     setActiveTab('markdown');
     try {
@@ -355,7 +373,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (event === 'chunk') {
             draftBuffer += data.text || '';
             el.markdownOutput.value = draftBuffer;
-            el.previewContent.innerHTML = marked.parse(draftBuffer);
+            syncDraftEditor();
             return;
           }
           if (event === 'result') {
@@ -879,9 +897,168 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
     renderVerification(data.verification);
     el.markdownOutput.value = data.draft;
-    el.previewContent.innerHTML = marked.parse(data.draft);
+    syncDraftEditor();
     el.draftResult.classList.remove('hidden');
     setActiveTab('preview');
+  }
+
+  function syncDraftEditor() {
+    el.previewContent.innerHTML = marked.parse(el.markdownOutput.value || '');
+    updateSectionControls();
+  }
+
+  function updateSectionControls() {
+    const section = currentMarkdownSection();
+    el.regenerateSection.disabled = !section || !state.profileId || !state.sessionId;
+    if (!el.markdownOutput.value.trim()) {
+      el.sectionStatus.textContent = '';
+      return;
+    }
+    el.sectionStatus.textContent = section
+      ? `選択中のセクション: ## ${section.heading}`
+      : '再生成するには Markdown タブで ## 見出し配下にカーソルを置いてください。';
+  }
+
+  async function regenerateCurrentSection() {
+    clearError();
+    const section = currentMarkdownSection();
+    if (!section) {
+      showError('再生成する ## セクションにカーソルを置いてください');
+      return;
+    }
+    el.regenerateSection.disabled = true;
+    el.sectionStatus.textContent = `## ${section.heading} を再生成しています。`;
+    rejectSectionCandidate();
+    try {
+      const data = await requestJSON(`/api/drafts/${encodeURIComponent(state.sessionId)}/regenerate-section`, {
+        method: 'POST',
+        body: {
+          style_profile_id: state.profileId,
+          session_id: state.sessionId,
+          persona_id: currentPersonaId(),
+          output_format_id: currentFormatId(),
+          draft_model: el.draftModel.value,
+          draft_markdown: el.markdownOutput.value,
+          section_anchor: section.anchor,
+        },
+      });
+      state.pendingSectionReplacement = data;
+      el.sectionCandidateOutput.value = data.replacement_markdown || '';
+      el.sectionCandidate.classList.remove('hidden');
+      el.sectionStatus.textContent = `## ${section.heading} の再生成候補を確認してください。`;
+      setActiveTab('markdown');
+      el.sectionCandidateOutput.focus();
+    } catch (error) {
+      showError(`セクション再生成に失敗しました: ${error.message}`);
+      updateSectionControls();
+    } finally {
+      el.regenerateSection.disabled = !currentMarkdownSection();
+    }
+  }
+
+  function acceptSectionCandidate() {
+    if (!state.pendingSectionReplacement) {
+      return;
+    }
+    const responseSection = state.pendingSectionReplacement.section || {};
+    const section = markdownSections(el.markdownOutput.value).find((candidate) => candidate.anchor === responseSection.anchor)
+      || currentMarkdownSection();
+    const updated = replaceMarkdownSection(el.markdownOutput.value, section, el.sectionCandidateOutput.value);
+    if (!updated) {
+      showError('候補の反映に失敗しました。対象セクションを再選択して再生成してください。');
+      return;
+    }
+    el.markdownOutput.value = updated;
+    rejectSectionCandidate();
+    syncDraftEditor();
+    el.markdownOutput.focus();
+  }
+
+  function rejectSectionCandidate() {
+    state.pendingSectionReplacement = null;
+    el.sectionCandidate.classList.add('hidden');
+    el.sectionCandidateOutput.value = '';
+  }
+
+  function currentMarkdownSection() {
+    return sectionAtOffset(el.markdownOutput.value, el.markdownOutput.selectionStart || 0);
+  }
+
+  function sectionAtOffset(markdown, offset) {
+    const sections = markdownSections(markdown);
+    return sections.find((section) => offset >= section.start && offset < section.end)
+      || sections.find((section) => offset === section.end)
+      || null;
+  }
+
+  function markdownSections(markdown) {
+    const headings = [];
+    let offset = 0;
+    const lines = markdown.match(/[^\n]*(?:\n|$)/g) || [];
+    lines.forEach((line) => {
+      if (!line) {
+        return;
+      }
+      const trimmed = line.replace(/\n$/, '').trim();
+      if (trimmed.startsWith('## ') && !trimmed.startsWith('### ')) {
+        const heading = trimmed.slice(3).trim();
+        headings.push({ offset, heading });
+      }
+      offset += line.length;
+    });
+    return headings.map((heading, index) => {
+      const end = index + 1 < headings.length ? headings[index + 1].offset : markdown.length;
+      return {
+        anchor: sectionAnchor(heading.heading),
+        heading: heading.heading,
+        start: heading.offset,
+        end,
+        content: markdown.slice(heading.offset, end),
+      };
+    });
+  }
+
+  function replaceMarkdownSection(markdown, section, replacement) {
+    if (!section || section.start < 0 || section.end < section.start || section.end > markdown.length) {
+      return '';
+    }
+    const candidate = normalizeReplacementSection(replacement, section.heading);
+    if (!candidate) {
+      return '';
+    }
+    return markdown.slice(0, section.start) + candidate + markdown.slice(section.end);
+  }
+
+  function normalizeReplacementSection(replacement, heading) {
+    let candidate = String(replacement || '').trim();
+    if (!candidate) {
+      return '';
+    }
+    if (!candidate.startsWith('## ')) {
+      candidate = `## ${heading}\n\n${candidate}`;
+    }
+    if (!candidate.endsWith('\n')) {
+      candidate += '\n';
+    }
+    const sections = markdownSections(candidate);
+    if (sections.length !== 1 || sections[0].anchor !== sectionAnchor(heading)) {
+      return '';
+    }
+    return candidate;
+  }
+
+  function sectionAnchor(heading) {
+    return String(heading || '')
+      .trim()
+      .replace(/^##\s+/, '')
+      .toLowerCase()
+      .replaceAll(' ', '-')
+      .replaceAll('　', '-')
+      .replaceAll('_', '-')
+      .replaceAll('/', '-')
+      .replace(/[:"'`?!：？！]/g, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
   }
 
   function renderVerification(verification) {
@@ -1020,6 +1197,16 @@ document.addEventListener('DOMContentLoaded', () => {
       el.copy.textContent = 'コピーしました';
       setTimeout(() => {
         el.copy.textContent = original;
+      }, 1600);
+    });
+  }
+
+  function copyPreviewText() {
+    navigator.clipboard.writeText(el.previewContent.innerText || '').then(() => {
+      const original = el.copyPreview.textContent;
+      el.copyPreview.textContent = 'コピーしました';
+      setTimeout(() => {
+        el.copyPreview.textContent = original;
       }, 1600);
     });
   }


### PR DESCRIPTION
## Summary

- Makes the generated Markdown textarea editable and live-syncs preview rendering.
- Adds preview/Markdown copy buttons plus a text-only section-regeneration candidate flow with accept/reject.
- Adds `POST /api/drafts/{id}/regenerate-section`, h2 section parser/replacer tests, handler coverage, and an Evo X2 section-regeneration scenario.
- Updates ADR 0002, implementation-plan docs, and validation notes for #19.

Closes #19

## Validation

- `go test ./...`
- `node --check static/js/script.js`
- `git diff --check`
- Local server smoke on `PORT=18080`: `/`, `/static/js/script.js`, `/api/personas`
- Evo X2 Tailnet scenario:
  - Base URL: `http://evo-x2.tailb30e58.ts.net/v1`
  - Draft model: `gemma4:31b`
  - Verify model: `gemma4:latest`
  - Section: `## 実装と検証：再現性の数値化`
  - Regeneration elapsed: `167.33s`
  - Verification elapsed: `23.14s`
  - Score: `72.1`
  - Verification: PASS
  - Non-target prefix/suffix unchanged: true/true
