### PR TITLE
Generalize source fetchers for #22

### DIFF
--- a/cmd/scenario/source_fetch/main.go
+++ b/cmd/scenario/source_fetch/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	sourcefetch "github.com/teradakousuke/note_maker/internal/infrastructure/source"
+)
+
+const defaultOutputDir = "tmp/source_fetch"
+
+func main() {
+	if os.Getenv("RUN_SOURCE_FETCH_SCENARIO") != "1" {
+		fatalf("set RUN_SOURCE_FETCH_SCENARIO=1 to run public source fetch scenario")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	outputDir := envOrDefault("SCENARIO_OUTPUT_DIR", defaultOutputDir)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		fatalf("create output dir: %v", err)
+	}
+
+	limit := 1
+	fetcher := sourcefetch.NewAuthorStyleFetcherWithClient(&http.Client{Timeout: 20 * time.Second})
+	selectors := map[string]string{
+		"note":  envOrDefault("SOURCE_FETCH_NOTE", "note:cor_instrument"),
+		"zenn":  envOrDefault("SOURCE_FETCH_ZENN", "zenn:zenn"),
+		"qiita": envOrDefault("SOURCE_FETCH_QIITA", "qiita:Qiita"),
+		"rss":   envOrDefault("SOURCE_FETCH_RSS", "rss:https://zenn.dev/zenn/feed"),
+	}
+
+	for name, selector := range selectors {
+		started := time.Now()
+		articles, err := fetcher.FetchUserLatestArticles(ctx, selector, limit)
+		if err != nil {
+			fatalf("fetch %s (%s): %v", name, selector, err)
+		}
+		path := filepath.Join(outputDir, name+".json")
+		writeJSON(path, articles)
+		fmt.Printf("%s selector=%s articles=%d elapsed_seconds=%.2f output=%s\n", name, selector, len(articles), time.Since(started).Seconds(), path)
+	}
+}
+
+func writeJSON(path string, value any) {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		fatalf("encode %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, append(encoded, '\n'), 0o644); err != nil {
+		fatalf("write %s: %v", path, err)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/docs/validation/issue-22-source-fetchers-2026-05-02.md
+++ b/docs/validation/issue-22-source-fetchers-2026-05-02.md
@@ -1,0 +1,68 @@
+# Issue 22 source fetcher validation
+
+Date: 2026-05-02
+
+## Scope
+
+Validate [#22](https://github.com/terisuke/note_maker/issues/22): route source acquisition beyond note.com to Zenn, Qiita, RSS/Atom, and generic HTML while keeping normal tests offline.
+
+## Current source facts checked
+
+- Qiita API v2 documents `GET /api/v2/users/:user_id/items` as the public user item list endpoint in newest order, with `page` and `per_page` parameters.
+- Qiita API v2 documents unauthenticated access as limited to `60` requests per hour per IP address, so the fetcher uses one request per user-list scenario and no polling loop.
+- Zenn's official RSS article documents user feeds as `https://zenn.dev/ユーザー名/feed`.
+- Zenn's official RSS article documents `?all=1` for including all public posts instead of the default limited feed, so the Zenn fetcher uses that query for user lists.
+- RSS/Atom parsing is implemented through standard XML feeds, with RSS 2.0 item fields and Atom entries handled in one `RSSFetcher`.
+
+## Implementation
+
+- `internal/domain/source` defines `Kind`, `Ref`, `ProfileSnapshot`, and `ArticleSnapshot`.
+- `internal/infrastructure/source.Router` dispatches by explicit selector or URL host:
+  - `note:<user>` and note.com URLs go to the existing note fetcher.
+  - `zenn:<user>` and zenn.dev URLs go to Zenn RSS/HTML fetchers.
+  - `qiita:<user>` and qiita.com URLs go to Qiita API v2 fetchers.
+  - `rss:<url>` and feed-like URLs go to RSS/Atom parsing.
+  - `html:<url>` and unknown article URLs go to semantic HTML extraction.
+- `AnalyzeAuthorStyleHandler` and the legacy article-generation handler now use the router through an adapter that still satisfies the existing `FetchArticle` / `FetchUserLatestArticles` application interface.
+
+## Scenario
+
+Command:
+
+```bash
+RUN_SOURCE_FETCH_SCENARIO=1 \
+SCENARIO_OUTPUT_DIR=tmp/source_fetch_issue22 \
+SOURCE_FETCH_NOTE=note:cor_instrument \
+SOURCE_FETCH_ZENN=zenn:zenn \
+SOURCE_FETCH_QIITA=qiita:Qiita \
+SOURCE_FETCH_RSS=rss:https://zenn.dev/zenn/feed \
+go run ./cmd/scenario/source_fetch
+```
+
+Result:
+
+| Source | Selector | Articles | Elapsed | Output |
+|---|---|---:|---:|---|
+| Qiita | `qiita:Qiita` | 1 | 0.68s | `tmp/source_fetch_issue22/qiita.json` |
+| RSS | `rss:https://zenn.dev/zenn/feed` | 1 | 0.18s | `tmp/source_fetch_issue22/rss.json` |
+| note | `note:cor_instrument` | 1 | 0.66s | `tmp/source_fetch_issue22/note.json` |
+| Zenn | `zenn:zenn` | 1 | 0.19s | `tmp/source_fetch_issue22/zenn.json` |
+
+Recent-source check:
+
+- Qiita returned `Qiita アップデートサマリー - 2026年4月`, which is inside the requested recent two-month window from 2026-05-02.
+- Zenn/RSS returned Zenn official content from the current public feed path.
+- note returned the latest public `cor_instrument` article available through the existing note source path.
+
+## Tests
+
+```bash
+go test ./...
+```
+
+Focused source tests cover:
+
+- RSS 2.0 `content:encoded` parsing.
+- Atom entry parsing.
+- explicit `zenn:`, `qiita:`, and `rss:` selector routing.
+- host-based routing for note.com, zenn.dev, qiita.com, RSS-like URLs, and generic HTML.

--- a/internal/domain/source/source.go
+++ b/internal/domain/source/source.go
@@ -1,0 +1,86 @@
+package source
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/teradakousuke/note_maker/internal/domain/article"
+)
+
+// Kind identifies a public writing source.
+type Kind string
+
+const (
+	KindNote  Kind = "note"
+	KindZenn  Kind = "zenn"
+	KindQiita Kind = "qiita"
+	KindRSS   Kind = "rss"
+	KindHTML  Kind = "html"
+)
+
+// Ref points to a public author, feed, or article.
+type Ref struct {
+	Kind Kind   `json:"kind"`
+	Ref  string `json:"ref,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// Validate rejects empty or unknown references.
+func (r Ref) Validate() error {
+	switch r.Kind {
+	case KindNote, KindZenn, KindQiita:
+		if strings.TrimSpace(r.Ref) == "" && strings.TrimSpace(r.URL) == "" {
+			return fmt.Errorf("%s source requires ref or url", r.Kind)
+		}
+	case KindRSS, KindHTML:
+		if strings.TrimSpace(r.URL) == "" {
+			return fmt.Errorf("%s source requires url", r.Kind)
+		}
+	default:
+		return fmt.Errorf("unsupported source kind %q", r.Kind)
+	}
+	return nil
+}
+
+// ProfileSnapshot describes a source account/feed at fetch time.
+type ProfileSnapshot struct {
+	Kind      Kind      `json:"kind"`
+	Ref       string    `json:"ref,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+// ArticleSnapshot is normalized source material from any public source.
+type ArticleSnapshot struct {
+	ID          string    `json:"id,omitempty"`
+	Kind        Kind      `json:"kind"`
+	URL         string    `json:"url"`
+	Title       string    `json:"title"`
+	Content     string    `json:"content"`
+	PublishedAt time.Time `json:"published_at,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty"`
+	FetchedAt   time.Time `json:"fetched_at"`
+}
+
+// ToArticle converts normalized source material into the existing article domain.
+func (a ArticleSnapshot) ToArticle() article.Article {
+	return article.Article{
+		URL:     strings.TrimSpace(a.URL),
+		Title:   strings.TrimSpace(a.Title),
+		Content: strings.TrimSpace(a.Content),
+	}
+}
+
+// Articles converts snapshots into article domain values.
+func Articles(snapshots []ArticleSnapshot) []article.Article {
+	articles := make([]article.Article, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		if strings.TrimSpace(snapshot.Content) == "" {
+			continue
+		}
+		articles = append(articles, snapshot.ToArticle())
+	}
+	return articles
+}

--- a/internal/handlers/generate.go
+++ b/internal/handlers/generate.go
@@ -9,7 +9,7 @@ import (
 	articleapp "github.com/teradakousuke/note_maker/internal/application/article"
 	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
 	"github.com/teradakousuke/note_maker/internal/infrastructure/llamacpp"
-	notenote "github.com/teradakousuke/note_maker/internal/infrastructure/note"
+	sourcefetch "github.com/teradakousuke/note_maker/internal/infrastructure/source"
 )
 
 // GenerateRequest は記事生成のリクエストボディの構造体
@@ -67,7 +67,7 @@ func newDefaultArticleService() (articleService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return articleapp.NewService(notenote.NewFetcher(), generator, nil), nil
+	return articleapp.NewService(sourcefetch.NewAuthorStyleFetcher(), generator, nil), nil
 }
 
 func handleGenerateArticle(service articleService, w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -22,8 +22,8 @@ import (
 	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
 	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 	"github.com/teradakousuke/note_maker/internal/infrastructure/llamacpp"
-	notenote "github.com/teradakousuke/note_maker/internal/infrastructure/note"
 	"github.com/teradakousuke/note_maker/internal/infrastructure/repository/memory"
+	sourcefetch "github.com/teradakousuke/note_maker/internal/infrastructure/source"
 )
 
 var workflowStore = newWorkflowStore()
@@ -177,7 +177,7 @@ func AnalyzeAuthorStyleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	service := authorstyleapp.NewAnalyzeAuthorStyleService(notenote.NewFetcher(), nil)
+	service := authorstyleapp.NewAnalyzeAuthorStyleService(sourcefetch.NewAuthorStyleFetcher(), nil)
 	result, err := service.Analyze(r.Context(), authorstyleapp.AnalyzeRequest{
 		Username:    req.Username,
 		ArticleURLs: req.ArticleURLs,

--- a/internal/infrastructure/source/html.go
+++ b/internal/infrastructure/source/html.go
@@ -1,0 +1,111 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+)
+
+// HTMLFetcher extracts readable content from public HTML pages.
+type HTMLFetcher struct {
+	client *http.Client
+}
+
+// NewHTMLFetcher creates a semantic HTML fetcher.
+func NewHTMLFetcher(client *http.Client) *HTMLFetcher {
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &HTMLFetcher{client: client}
+}
+
+// FetchArticle retrieves one public HTML article.
+func (f *HTMLFetcher) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSpace(ref.URL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create html request: %w", err)
+	}
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	response, err := f.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch html: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch html: unexpected status %s", response.Status)
+	}
+	doc, err := goquery.NewDocumentFromReader(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parse html: %w", err)
+	}
+	title := firstNonEmpty(
+		selectionAttr(doc, `meta[property="og:title"]`, "content"),
+		selectionAttr(doc, `meta[name="twitter:title"]`, "content"),
+		selectionText(doc, "h1"),
+		selectionText(doc, "title"),
+	)
+	content := firstNonEmpty(
+		selectionBlockText(doc, "article"),
+		selectionBlockText(doc, "main"),
+		selectionBlockText(doc, `[role="main"]`),
+		selectionBlockText(doc, ".content"),
+	)
+	if content == "" {
+		return nil, fmt.Errorf("html did not contain extractable article content")
+	}
+	now := time.Now().UTC()
+	return &sourcedomain.ArticleSnapshot{
+		ID:        ref.URL,
+		Kind:      sourcedomain.KindHTML,
+		URL:       ref.URL,
+		Title:     normalizeWhitespace(title),
+		Content:   content,
+		FetchedAt: now,
+	}, nil
+}
+
+// FetchList is intentionally unsupported for arbitrary HTML because page-list
+// extraction is site-specific and would silently scrape the wrong surface.
+func (f *HTMLFetcher) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int) ([]sourcedomain.ArticleSnapshot, error) {
+	article, err := f.FetchArticle(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return []sourcedomain.ArticleSnapshot{*article}, nil
+}
+
+func selectionText(doc *goquery.Document, selector string) string {
+	return strings.TrimSpace(doc.Find(selector).First().Text())
+}
+
+func selectionBlockText(doc *goquery.Document, selector string) string {
+	selection := doc.Find(selector).First()
+	if selection.Length() == 0 {
+		return ""
+	}
+	parts := make([]string, 0)
+	selection.Find("h1,h2,h3,h4,p,li,blockquote,pre,code").Each(func(_ int, s *goquery.Selection) {
+		text := normalizeWhitespace(s.Text())
+		if text != "" {
+			parts = append(parts, text)
+		}
+	})
+	if len(parts) == 0 {
+		return normalizeParagraphs(selection.Text())
+	}
+	return normalizeParagraphs(strings.Join(parts, "\n\n"))
+}
+
+func selectionAttr(doc *goquery.Document, selector, attr string) string {
+	value, _ := doc.Find(selector).First().Attr(attr)
+	return strings.TrimSpace(value)
+}

--- a/internal/infrastructure/source/qiita.go
+++ b/internal/infrastructure/source/qiita.go
@@ -1,0 +1,146 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+)
+
+// QiitaFetcher reads public Qiita posts through Qiita API v2.
+type QiitaFetcher struct {
+	client *http.Client
+}
+
+// NewQiitaFetcher creates a Qiita API fetcher.
+func NewQiitaFetcher(client *http.Client) *QiitaFetcher {
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &QiitaFetcher{client: client}
+}
+
+// FetchList fetches public posts from a user in newest order.
+func (f *QiitaFetcher) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int) ([]sourcedomain.ArticleSnapshot, error) {
+	userID := strings.Trim(strings.TrimSpace(ref.Ref), "/")
+	if userID == "" && strings.TrimSpace(ref.URL) != "" {
+		parsed, err := url.Parse(strings.TrimSpace(ref.URL))
+		if err != nil {
+			return nil, fmt.Errorf("parse qiita url: %w", err)
+		}
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) > 0 {
+			userID = parts[0]
+		}
+	}
+	if userID == "" {
+		return nil, fmt.Errorf("qiita user ref is required")
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	apiURL := fmt.Sprintf("https://qiita.com/api/v2/users/%s/items?page=1&per_page=%d", url.PathEscape(userID), min(limit, 100))
+	var payload []qiitaItem
+	if err := f.getJSON(ctx, apiURL, &payload); err != nil {
+		return nil, err
+	}
+	return qiitaSnapshots(payload, limit), nil
+}
+
+// FetchArticle fetches one public Qiita item by item id parsed from its URL.
+func (f *QiitaFetcher) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	itemID := qiitaItemID(ref.URL)
+	if itemID == "" {
+		return nil, fmt.Errorf("could not extract qiita item id from %s", ref.URL)
+	}
+	apiURL := fmt.Sprintf("https://qiita.com/api/v2/items/%s", url.PathEscape(itemID))
+	var payload qiitaItem
+	if err := f.getJSON(ctx, apiURL, &payload); err != nil {
+		return nil, err
+	}
+	snapshots := qiitaSnapshots([]qiitaItem{payload}, 1)
+	if len(snapshots) == 0 {
+		return nil, fmt.Errorf("qiita item had no body")
+	}
+	return &snapshots[0], nil
+}
+
+func (f *QiitaFetcher) getJSON(ctx context.Context, apiURL string, out any) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return fmt.Errorf("create qiita request: %w", err)
+	}
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("Accept", "application/json")
+	response, err := f.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("fetch qiita api: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("fetch qiita api: unexpected status %s", response.Status)
+	}
+	if err := json.NewDecoder(response.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode qiita api: %w", err)
+	}
+	return nil
+}
+
+func qiitaSnapshots(items []qiitaItem, limit int) []sourcedomain.ArticleSnapshot {
+	now := time.Now().UTC()
+	snapshots := make([]sourcedomain.ArticleSnapshot, 0, min(limit, len(items)))
+	for _, item := range items {
+		if len(snapshots) >= limit {
+			break
+		}
+		content := strings.TrimSpace(item.Body)
+		if content == "" {
+			content = htmlToParagraphText(item.RenderedBody)
+		}
+		if content == "" {
+			continue
+		}
+		createdAt := parseFeedTime(item.CreatedAt)
+		updatedAt := parseFeedTime(item.UpdatedAt)
+		snapshots = append(snapshots, sourcedomain.ArticleSnapshot{
+			ID:          item.ID,
+			Kind:        sourcedomain.KindQiita,
+			URL:         item.URL,
+			Title:       item.Title,
+			Content:     content,
+			PublishedAt: createdAt,
+			UpdatedAt:   updatedAt,
+			FetchedAt:   now,
+		})
+	}
+	return snapshots
+}
+
+func qiitaItemID(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i, part := range parts {
+		if part == "items" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+type qiitaItem struct {
+	ID           string `json:"id"`
+	URL          string `json:"url"`
+	Title        string `json:"title"`
+	Body         string `json:"body"`
+	RenderedBody string `json:"rendered_body"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}

--- a/internal/infrastructure/source/router.go
+++ b/internal/infrastructure/source/router.go
@@ -1,0 +1,210 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	articledomain "github.com/teradakousuke/note_maker/internal/domain/article"
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+	notenote "github.com/teradakousuke/note_maker/internal/infrastructure/note"
+)
+
+// Router dispatches public source refs to concrete fetchers.
+type Router struct {
+	note  *notenote.Fetcher
+	zenn  *ZennFetcher
+	qiita *QiitaFetcher
+	rss   *RSSFetcher
+	html  *HTMLFetcher
+}
+
+// NewRouter creates a source router with shared HTTP settings.
+func NewRouter() *Router {
+	return NewRouterWithClient(nil)
+}
+
+// NewRouterWithClient creates a source router with a caller-provided client.
+func NewRouterWithClient(client *http.Client) *Router {
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &Router{
+		note:  notenote.NewFetcherWithClient(client),
+		zenn:  NewZennFetcher(client),
+		qiita: NewQiitaFetcher(client),
+		rss:   NewRSSFetcher(client),
+		html:  NewHTMLFetcher(client),
+	}
+}
+
+// FetchList fetches recent articles for an author/feed ref.
+func (r *Router) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int) ([]sourcedomain.ArticleSnapshot, error) {
+	ref = normalizeRef(ref)
+	switch ref.Kind {
+	case sourcedomain.KindNote:
+		articles, err := r.note.FetchUserLatestArticles(ctx, ref.Ref, limit)
+		return snapshotsFromArticles(sourcedomain.KindNote, articles), err
+	case sourcedomain.KindZenn:
+		return r.zenn.FetchList(ctx, ref, limit)
+	case sourcedomain.KindQiita:
+		return r.qiita.FetchList(ctx, ref, limit)
+	case sourcedomain.KindRSS:
+		return r.rss.FetchList(ctx, ref, limit)
+	case sourcedomain.KindHTML:
+		return r.html.FetchList(ctx, ref, limit)
+	default:
+		return nil, fmt.Errorf("unsupported source kind %q", ref.Kind)
+	}
+}
+
+// FetchArticle fetches one article by URL.
+func (r *Router) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	ref = normalizeRef(ref)
+	switch ref.Kind {
+	case sourcedomain.KindNote:
+		article, err := r.note.FetchArticle(ctx, ref.URL)
+		if err != nil {
+			return nil, err
+		}
+		snapshot := snapshotFromArticle(sourcedomain.KindNote, *article)
+		return &snapshot, nil
+	case sourcedomain.KindZenn:
+		return r.zenn.FetchArticle(ctx, ref)
+	case sourcedomain.KindQiita:
+		return r.qiita.FetchArticle(ctx, ref)
+	case sourcedomain.KindRSS:
+		return r.rss.FetchArticle(ctx, ref)
+	case sourcedomain.KindHTML:
+		return r.html.FetchArticle(ctx, ref)
+	default:
+		return nil, fmt.Errorf("unsupported source kind %q", ref.Kind)
+	}
+}
+
+// AuthorStyleFetcher adapts Router to application/authorstyle.SourceFetcher.
+type AuthorStyleFetcher struct {
+	router *Router
+}
+
+// NewAuthorStyleFetcher creates an author-style source adapter.
+func NewAuthorStyleFetcher() *AuthorStyleFetcher {
+	return &AuthorStyleFetcher{router: NewRouter()}
+}
+
+// NewAuthorStyleFetcherWithClient creates a testable author-style source adapter.
+func NewAuthorStyleFetcherWithClient(client *http.Client) *AuthorStyleFetcher {
+	return &AuthorStyleFetcher{router: NewRouterWithClient(client)}
+}
+
+// FetchArticle routes by URL host. note.com remains enforced inside the note fetcher only.
+func (f *AuthorStyleFetcher) FetchArticle(ctx context.Context, articleURL string) (*articledomain.Article, error) {
+	snapshot, err := f.router.FetchArticle(ctx, RefFromURL(articleURL))
+	if err != nil {
+		return nil, err
+	}
+	article := snapshot.ToArticle()
+	return &article, nil
+}
+
+// FetchUserLatestArticles supports explicit refs such as zenn:cloudia,
+// qiita:Cloudia_Cor_Inc, rss:https://example.com/feed.xml, and legacy note usernames.
+func (f *AuthorStyleFetcher) FetchUserLatestArticles(ctx context.Context, username string, limit int) ([]articledomain.Article, error) {
+	snapshots, err := f.router.FetchList(ctx, RefFromSelector(username), limit)
+	if err != nil {
+		return nil, err
+	}
+	return sourcedomain.Articles(snapshots), nil
+}
+
+// RefFromSelector parses UI/API source selectors.
+func RefFromSelector(selector string) sourcedomain.Ref {
+	selector = strings.TrimSpace(selector)
+	if parsed, ok := parseKindSelector(selector); ok {
+		return parsed
+	}
+	if looksLikeURL(selector) {
+		return RefFromURL(selector)
+	}
+	return sourcedomain.Ref{Kind: sourcedomain.KindNote, Ref: strings.Trim(selector, "/")}
+}
+
+// RefFromURL routes article/feed URLs by host.
+func RefFromURL(rawURL string) sourcedomain.Ref {
+	rawURL = strings.TrimSpace(rawURL)
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return sourcedomain.Ref{Kind: sourcedomain.KindHTML, URL: rawURL}
+	}
+	host := strings.ToLower(parsed.Hostname())
+	switch {
+	case host == "note.com" || strings.HasSuffix(host, ".note.com"):
+		return sourcedomain.Ref{Kind: sourcedomain.KindNote, URL: rawURL}
+	case host == "zenn.dev" || strings.HasSuffix(host, ".zenn.dev"):
+		return sourcedomain.Ref{Kind: sourcedomain.KindZenn, URL: rawURL}
+	case host == "qiita.com" || strings.HasSuffix(host, ".qiita.com"):
+		return sourcedomain.Ref{Kind: sourcedomain.KindQiita, URL: rawURL}
+	case strings.Contains(strings.ToLower(parsed.Path), "rss") || strings.Contains(strings.ToLower(parsed.Path), "feed") || strings.HasSuffix(strings.ToLower(parsed.Path), ".xml"):
+		return sourcedomain.Ref{Kind: sourcedomain.KindRSS, URL: rawURL}
+	default:
+		return sourcedomain.Ref{Kind: sourcedomain.KindHTML, URL: rawURL}
+	}
+}
+
+func normalizeRef(ref sourcedomain.Ref) sourcedomain.Ref {
+	if ref.Kind == "" {
+		if strings.TrimSpace(ref.URL) != "" {
+			return RefFromURL(ref.URL)
+		}
+		return RefFromSelector(ref.Ref)
+	}
+	return ref
+}
+
+func parseKindSelector(selector string) (sourcedomain.Ref, bool) {
+	prefix, value, ok := strings.Cut(selector, ":")
+	if !ok {
+		return sourcedomain.Ref{}, false
+	}
+	value = strings.TrimSpace(value)
+	switch strings.ToLower(strings.TrimSpace(prefix)) {
+	case "note":
+		return sourcedomain.Ref{Kind: sourcedomain.KindNote, Ref: strings.Trim(value, "/")}, true
+	case "zenn":
+		return sourcedomain.Ref{Kind: sourcedomain.KindZenn, Ref: strings.Trim(value, "/")}, true
+	case "qiita":
+		return sourcedomain.Ref{Kind: sourcedomain.KindQiita, Ref: strings.Trim(value, "/")}, true
+	case "rss":
+		return sourcedomain.Ref{Kind: sourcedomain.KindRSS, URL: value}, true
+	case "html":
+		return sourcedomain.Ref{Kind: sourcedomain.KindHTML, URL: value}, true
+	default:
+		return sourcedomain.Ref{}, false
+	}
+}
+
+func looksLikeURL(value string) bool {
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.Scheme != "" && parsed.Host != ""
+}
+
+func snapshotsFromArticles(kind sourcedomain.Kind, articles []articledomain.Article) []sourcedomain.ArticleSnapshot {
+	snapshots := make([]sourcedomain.ArticleSnapshot, 0, len(articles))
+	for _, article := range articles {
+		snapshots = append(snapshots, snapshotFromArticle(kind, article))
+	}
+	return snapshots
+}
+
+func snapshotFromArticle(kind sourcedomain.Kind, article articledomain.Article) sourcedomain.ArticleSnapshot {
+	return sourcedomain.ArticleSnapshot{
+		ID:      firstNonEmpty(article.URL, article.Title),
+		Kind:    kind,
+		URL:     article.URL,
+		Title:   article.Title,
+		Content: article.Content,
+	}
+}

--- a/internal/infrastructure/source/rss.go
+++ b/internal/infrastructure/source/rss.go
@@ -1,0 +1,224 @@
+package source
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+)
+
+const userAgent = "note-maker/2026.05 (+https://github.com/terisuke/note_maker)"
+
+// RSSFetcher reads RSS 2.0 and Atom feeds.
+type RSSFetcher struct {
+	client *http.Client
+}
+
+// NewRSSFetcher creates a feed fetcher.
+func NewRSSFetcher(client *http.Client) *RSSFetcher {
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &RSSFetcher{client: client}
+}
+
+// FetchList returns feed entries in feed order, normally newest first.
+func (f *RSSFetcher) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int) ([]sourcedomain.ArticleSnapshot, error) {
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSpace(ref.URL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create feed request: %w", err)
+	}
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("Accept", "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8")
+	response, err := f.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch feed: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch feed: unexpected status %s", response.Status)
+	}
+	return parseFeed(response.Body, ref, limit, time.Now().UTC())
+}
+
+// FetchArticle returns the first matching feed item when the ref URL is a feed.
+func (f *RSSFetcher) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	items, err := f.FetchList(ctx, ref, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("feed contained no articles")
+	}
+	return &items[0], nil
+}
+
+func parseFeed(reader io.Reader, ref sourcedomain.Ref, limit int, fetchedAt time.Time) ([]sourcedomain.ArticleSnapshot, error) {
+	encoded, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read feed: %w", err)
+	}
+	var rss rssDocument
+	if err := xml.Unmarshal(encoded, &rss); err == nil && len(rss.Channel.Items) > 0 {
+		return rssSnapshots(rss.Channel.Items, ref, limit, fetchedAt), nil
+	}
+	var atom atomFeed
+	if err := xml.Unmarshal(encoded, &atom); err == nil && len(atom.Entries) > 0 {
+		return atomSnapshots(atom.Entries, ref, limit, fetchedAt), nil
+	}
+	return nil, fmt.Errorf("feed contained no RSS items or Atom entries")
+}
+
+func rssSnapshots(items []rssItem, ref sourcedomain.Ref, limit int, fetchedAt time.Time) []sourcedomain.ArticleSnapshot {
+	snapshots := make([]sourcedomain.ArticleSnapshot, 0, min(limit, len(items)))
+	for _, item := range items {
+		if len(snapshots) >= limit {
+			break
+		}
+		link := strings.TrimSpace(item.Link)
+		if link == "" {
+			link = strings.TrimSpace(item.GUID.Value)
+		}
+		content := firstNonEmpty(item.EncodedContent, item.Description)
+		content = htmlToParagraphText(content)
+		if content == "" {
+			continue
+		}
+		publishedAt := parseFeedTime(firstNonEmpty(item.PubDate, item.Date))
+		snapshots = append(snapshots, sourcedomain.ArticleSnapshot{
+			ID:          firstNonEmpty(item.GUID.Value, link),
+			Kind:        ref.Kind,
+			URL:         link,
+			Title:       normalizeWhitespace(item.Title),
+			Content:     content,
+			PublishedAt: publishedAt,
+			UpdatedAt:   publishedAt,
+			FetchedAt:   fetchedAt,
+		})
+	}
+	return snapshots
+}
+
+func atomSnapshots(entries []atomEntry, ref sourcedomain.Ref, limit int, fetchedAt time.Time) []sourcedomain.ArticleSnapshot {
+	snapshots := make([]sourcedomain.ArticleSnapshot, 0, min(limit, len(entries)))
+	for _, entry := range entries {
+		if len(snapshots) >= limit {
+			break
+		}
+		link := atomEntryLink(entry)
+		content := htmlToParagraphText(cleanXMLText(firstNonEmpty(entry.Content.Value, entry.Summary.Value)))
+		if content == "" {
+			continue
+		}
+		publishedAt := parseFeedTime(firstNonEmpty(entry.Published, entry.Updated))
+		updatedAt := parseFeedTime(entry.Updated)
+		snapshots = append(snapshots, sourcedomain.ArticleSnapshot{
+			ID:          firstNonEmpty(entry.ID, link),
+			Kind:        ref.Kind,
+			URL:         link,
+			Title:       normalizeWhitespace(entry.Title),
+			Content:     content,
+			PublishedAt: publishedAt,
+			UpdatedAt:   updatedAt,
+			FetchedAt:   fetchedAt,
+		})
+	}
+	return snapshots
+}
+
+func atomEntryLink(entry atomEntry) string {
+	for _, link := range entry.Links {
+		if strings.TrimSpace(link.Rel) == "" || link.Rel == "alternate" {
+			if strings.TrimSpace(link.Href) != "" {
+				return strings.TrimSpace(link.Href)
+			}
+		}
+	}
+	if len(entry.Links) > 0 {
+		return strings.TrimSpace(entry.Links[0].Href)
+	}
+	return ""
+}
+
+func parseFeedTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	layouts := []string{
+		time.RFC1123Z,
+		time.RFC1123,
+		time.RFC3339,
+		time.RFC3339Nano,
+		"Mon, 02 Jan 2006 15:04:05 -0700",
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+type rssDocument struct {
+	Channel struct {
+		Items []rssItem `xml:"item"`
+	} `xml:"channel"`
+}
+
+type rssItem struct {
+	Title          string  `xml:"title"`
+	Link           string  `xml:"link"`
+	Description    string  `xml:"description"`
+	PubDate        string  `xml:"pubDate"`
+	Date           string  `xml:"http://purl.org/dc/elements/1.1/ date"`
+	EncodedContent string  `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
+	GUID           rssGUID `xml:"guid"`
+}
+
+type rssGUID struct {
+	Value string `xml:",chardata"`
+}
+
+type atomFeed struct {
+	Entries []atomEntry `xml:"entry"`
+}
+
+type atomEntry struct {
+	ID        string       `xml:"id"`
+	Title     string       `xml:"title"`
+	Updated   string       `xml:"updated"`
+	Published string       `xml:"published"`
+	Links     []atomLink   `xml:"link"`
+	Summary   atomTextNode `xml:"summary"`
+	Content   atomTextNode `xml:"content"`
+}
+
+type atomLink struct {
+	Rel  string `xml:"rel,attr"`
+	Href string `xml:"href,attr"`
+}
+
+type atomTextNode struct {
+	Value string `xml:",innerxml"`
+}
+
+func cleanXMLText(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "<![CDATA[")
+	value = strings.TrimSuffix(value, "]]>")
+	return strings.TrimSpace(value)
+}

--- a/internal/infrastructure/source/rss_test.go
+++ b/internal/infrastructure/source/rss_test.go
@@ -1,0 +1,130 @@
+package source
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+)
+
+func TestRSSFetcherParsesRSS2ContentEncoded(t *testing.T) {
+	feed := `<?xml version="1.0"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <item>
+      <title>最新記事</title>
+      <link>https://example.com/post-1</link>
+      <guid>post-1</guid>
+      <pubDate>Sat, 02 May 2026 12:00:00 +0900</pubDate>
+      <content:encoded><![CDATA[<p>本文です。</p><p>続きです。</p>]]></content:encoded>
+    </item>
+  </channel>
+</rss>`
+	snapshots, err := parseFeed(strings.NewReader(feed), sourcedomain.Ref{Kind: sourcedomain.KindRSS, URL: "https://example.com/feed.xml"}, 5, testFetchedAt)
+	if err != nil {
+		t.Fatalf("parse feed: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("len = %d", len(snapshots))
+	}
+	if snapshots[0].Title != "最新記事" || snapshots[0].Content != "本文です。\n\n続きです。" {
+		t.Fatalf("unexpected snapshot: %#v", snapshots[0])
+	}
+	if snapshots[0].PublishedAt.IsZero() {
+		t.Fatalf("published time was not parsed")
+	}
+}
+
+func TestRSSFetcherParsesAtom(t *testing.T) {
+	feed := `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>tag:example.com,2026:1</id>
+    <title>Atom記事</title>
+    <updated>2026-05-02T12:00:00+09:00</updated>
+    <link rel="alternate" href="https://example.com/atom-1" />
+    <content type="html"><![CDATA[<p>Atom本文</p>]]></content>
+  </entry>
+</feed>`
+	snapshots, err := parseFeed(strings.NewReader(feed), sourcedomain.Ref{Kind: sourcedomain.KindRSS, URL: "https://example.com/atom.xml"}, 5, testFetchedAt)
+	if err != nil {
+		t.Fatalf("parse atom: %v", err)
+	}
+	if len(snapshots) != 1 || snapshots[0].URL != "https://example.com/atom-1" || snapshots[0].Content != "Atom本文" {
+		t.Fatalf("unexpected snapshots: %#v", snapshots)
+	}
+}
+
+func TestAuthorStyleFetcherRoutesExplicitSources(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/zenn-user/feed":
+			if r.URL.Query().Get("all") != "1" {
+				t.Fatalf("zenn feed should request all=1, got %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><rss><channel><item><title>Zenn</title><link>https://zenn.dev/zenn-user/articles/a</link><description><![CDATA[<p>Zenn本文</p>]]></description></item></channel></rss>`))
+		case "/api/v2/users/qiita-user/items":
+			_, _ = w.Write([]byte(`[{"id":"abc","url":"https://qiita.com/qiita-user/items/abc","title":"Qiita","body":"# Qiita本文","created_at":"2026-05-02T00:00:00+09:00","updated_at":"2026-05-02T00:00:00+09:00"}]`))
+		case "/feed.xml":
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><rss><channel><item><title>RSS</title><link>https://example.com/rss</link><description><![CDATA[<p>RSS本文</p>]]></description></item></channel></rss>`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewAuthorStyleFetcherWithClient(mappedClient(server.URL))
+	cases := map[string]string{
+		"zenn:zenn-user":         "Zenn本文",
+		"qiita:qiita-user":       "# Qiita本文",
+		"rss:https://x/feed.xml": "RSS本文",
+	}
+	for selector, wantContent := range cases {
+		articles, err := fetcher.FetchUserLatestArticles(context.Background(), selector, 3)
+		if err != nil {
+			t.Fatalf("%s: fetch latest: %v", selector, err)
+		}
+		if len(articles) != 1 || articles[0].Content != wantContent {
+			t.Fatalf("%s: unexpected articles: %#v", selector, articles)
+		}
+	}
+}
+
+func TestRefFromURLRoutesKnownHosts(t *testing.T) {
+	tests := map[string]sourcedomain.Kind{
+		"https://note.com/user/n/n1":         sourcedomain.KindNote,
+		"https://zenn.dev/user/articles/abc": sourcedomain.KindZenn,
+		"https://qiita.com/user/items/abc":   sourcedomain.KindQiita,
+		"https://example.com/rss.xml":        sourcedomain.KindRSS,
+		"https://example.com/blog/post":      sourcedomain.KindHTML,
+	}
+	for rawURL, want := range tests {
+		if got := RefFromURL(rawURL).Kind; got != want {
+			t.Fatalf("%s kind = %s, want %s", rawURL, got, want)
+		}
+	}
+}
+
+var testFetchedAt = parseFeedTime("2026-05-02T00:00:00+09:00")
+
+func mappedClient(target string) *http.Client {
+	targetURL, _ := url.Parse(target)
+	return &http.Client{Transport: rewriteTransport{target: targetURL, next: http.DefaultTransport}}
+}
+
+type rewriteTransport struct {
+	target *url.URL
+	next   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	clone := r.Clone(r.Context())
+	clone.URL.Scheme = t.target.Scheme
+	clone.URL.Host = t.target.Host
+	clone.Host = t.target.Host
+	return t.next.RoundTrip(clone)
+}

--- a/internal/infrastructure/source/text.go
+++ b/internal/infrastructure/source/text.go
@@ -1,0 +1,61 @@
+package source
+
+import (
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func normalizeWhitespace(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
+
+func normalizeParagraphs(value string) string {
+	lines := strings.Split(strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n"), "\n")
+	normalized := make([]string, 0, len(lines))
+	blank := false
+	for _, line := range lines {
+		line = normalizeWhitespace(line)
+		if line == "" {
+			if !blank {
+				normalized = append(normalized, "")
+			}
+			blank = true
+			continue
+		}
+		blank = false
+		normalized = append(normalized, line)
+	}
+	return strings.TrimSpace(strings.Join(normalized, "\n"))
+}
+
+func htmlToParagraphText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(value))
+	if err != nil {
+		return normalizeParagraphs(value)
+	}
+	parts := make([]string, 0)
+	doc.Find("h1,h2,h3,h4,p,li,blockquote,pre,code").Each(func(_ int, s *goquery.Selection) {
+		text := normalizeWhitespace(s.Text())
+		if text != "" {
+			parts = append(parts, text)
+		}
+	})
+	if len(parts) == 0 {
+		return normalizeParagraphs(doc.Text())
+	}
+	return normalizeParagraphs(strings.Join(parts, "\n\n"))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/infrastructure/source/zenn.go
+++ b/internal/infrastructure/source/zenn.go
@@ -1,0 +1,63 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+)
+
+// ZennFetcher reads Zenn public articles through the official RSS feed shape.
+type ZennFetcher struct {
+	rss  *RSSFetcher
+	html *HTMLFetcher
+}
+
+// NewZennFetcher creates a Zenn fetcher.
+func NewZennFetcher(client *http.Client) *ZennFetcher {
+	return &ZennFetcher{
+		rss:  NewRSSFetcher(client),
+		html: NewHTMLFetcher(client),
+	}
+}
+
+// FetchList fetches a user's public Zenn feed. `all=1` is used so older public
+// posts are not silently hidden by the default feed size.
+func (f *ZennFetcher) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int) ([]sourcedomain.ArticleSnapshot, error) {
+	user := strings.Trim(strings.TrimSpace(ref.Ref), "/")
+	if user == "" && strings.TrimSpace(ref.URL) != "" {
+		parsed, err := url.Parse(strings.TrimSpace(ref.URL))
+		if err != nil {
+			return nil, fmt.Errorf("parse zenn url: %w", err)
+		}
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) > 0 {
+			user = parts[0]
+		}
+	}
+	if user == "" {
+		return nil, fmt.Errorf("zenn user ref is required")
+	}
+	feedURL := fmt.Sprintf("https://zenn.dev/%s/feed?all=1", url.PathEscape(user))
+	snapshots, err := f.rss.FetchList(ctx, sourcedomain.Ref{Kind: sourcedomain.KindZenn, Ref: user, URL: feedURL}, limit)
+	if err != nil {
+		return nil, err
+	}
+	for i := range snapshots {
+		snapshots[i].Kind = sourcedomain.KindZenn
+	}
+	return snapshots, nil
+}
+
+// FetchArticle fetches one Zenn article page.
+func (f *ZennFetcher) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	article, err := f.html.FetchArticle(ctx, sourcedomain.Ref{Kind: sourcedomain.KindHTML, URL: ref.URL})
+	if err != nil {
+		return nil, err
+	}
+	article.Kind = sourcedomain.KindZenn
+	return article, nil
+}


### PR DESCRIPTION
## Summary

- Adds `internal/domain/source` and a routed source acquisition layer for note, Zenn, Qiita, RSS/Atom, and generic HTML.
- Switches author-style analysis and the legacy generate handler from note-only fetcher construction to the source router adapter.
- Adds `cmd/scenario/source_fetch` and validation notes for #22.

Closes #22

## Current-source basis

- Qiita API v2 docs currently document `GET /api/v2/users/:user_id/items` as newest-order public user item listing, with `page` / `per_page`, and unauthenticated rate limit of 60 requests/hour/IP.
- Zenn official RSS docs currently document `/ユーザー名/feed` and `?all=1` for all public posts.
- RSS/Atom parsing is implemented as XML feed parsing, not hard-coded to one blog engine.

## Validation

- `go test ./...`
- `RUN_SOURCE_FETCH_SCENARIO=1 ... go run ./cmd/scenario/source_fetch`
  - Qiita: `Qiita アップデートサマリー - 2026年4月`, 0.68s
  - RSS: Zenn official feed, 0.18s
  - note: `cor_instrument`, 0.66s
  - Zenn: `zenn`, 0.19s

Validation notes: `docs/validation/issue-22-source-fetchers-2026-05-02.md`
