### PR TITLE
Fix historical source fetching for #22

### DIFF
--- a/cmd/scenario/source_fetch/main.go
+++ b/cmd/scenario/source_fetch/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,24 +28,28 @@ func main() {
 		fatalf("create output dir: %v", err)
 	}
 
-	limit := 1
+	limit := envIntOrDefault("SOURCE_FETCH_LIMIT", 20)
 	fetcher := sourcefetch.NewAuthorStyleFetcherWithClient(&http.Client{Timeout: 20 * time.Second})
-	selectors := map[string]string{
-		"note":  envOrDefault("SOURCE_FETCH_NOTE", "note:cor_instrument"),
-		"zenn":  envOrDefault("SOURCE_FETCH_ZENN", "zenn:zenn"),
-		"qiita": envOrDefault("SOURCE_FETCH_QIITA", "qiita:Qiita"),
-		"rss":   envOrDefault("SOURCE_FETCH_RSS", "rss:https://zenn.dev/zenn/feed"),
+	selectors := []struct {
+		name     string
+		selector string
+	}{
+		{"note", envOrDefault("SOURCE_FETCH_NOTE", "note:cor_instrument")},
+		{"zenn", envOrDefault("SOURCE_FETCH_ZENN", "zenn:cloudia")},
+		{"qiita", envOrDefault("SOURCE_FETCH_QIITA", "qiita:Cloudia_Cor_Inc")},
+		{"rss", envOrDefault("SOURCE_FETCH_RSS", "rss:https://cor-jp.com/rss.xml")},
+		{"github", envOrDefault("SOURCE_FETCH_GITHUB", "github:Cor-Incorporated/corsweb2024/src/content/blog/ja")},
 	}
 
-	for name, selector := range selectors {
+	for _, source := range selectors {
 		started := time.Now()
-		articles, err := fetcher.FetchUserLatestArticles(ctx, selector, limit)
+		articles, err := fetcher.FetchUserLatestArticles(ctx, source.selector, limit)
 		if err != nil {
-			fatalf("fetch %s (%s): %v", name, selector, err)
+			fatalf("fetch %s (%s): %v", source.name, source.selector, err)
 		}
-		path := filepath.Join(outputDir, name+".json")
+		path := filepath.Join(outputDir, source.name+".json")
 		writeJSON(path, articles)
-		fmt.Printf("%s selector=%s articles=%d elapsed_seconds=%.2f output=%s\n", name, selector, len(articles), time.Since(started).Seconds(), path)
+		fmt.Printf("%s selector=%s limit=%d articles=%d elapsed_seconds=%.2f output=%s\n", source.name, source.selector, limit, len(articles), time.Since(started).Seconds(), path)
 	}
 }
 
@@ -63,6 +68,18 @@ func envOrDefault(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func envIntOrDefault(key string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
 }
 
 func fatalf(format string, args ...any) {

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -148,7 +148,7 @@ New domain types under `internal/domain`:
 ## Infrastructure Changes
 
 - `internal/infrastructure/repository/sqlite` — new package implementing every repository interface; the JSON file repository becomes an export/import utility for portability.
-- `internal/infrastructure/source/{note,zenn,qiita,rss,html}` — per-source fetchers behind a common interface in `internal/domain/source` (or kept under `infrastructure` and bound by interface in `domain/persona`).
+- `internal/infrastructure/source/{note,zenn,qiita,rss,html,github}` — per-source fetchers behind a common interface in `internal/domain/source` (or kept under `infrastructure` and bound by interface in `domain/persona`). GitHub-backed Markdown is required for Cor.inc blog because the public RSS feed is a discovery source with summaries, while `corsweb2024/src/content/blog/ja/*.md` is the canonical full-body source.
 - `internal/infrastructure/llamacpp` — gains streaming (SSE) support; existing non-streaming path retained for tests.
 
 ## API Changes

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -155,12 +155,13 @@ Concrete implementations under `internal/infrastructure/source/`:
 - `qiita/` — public REST API (no auth needed for read-only public posts) + HTML fallback.
 - `rss/` — generic RSS reader for Astro/Jekyll/Hugo blogs.
 - `html/` — generic semantic-content extractor (last resort).
+- `github/` — public repository Markdown reader for canonical blog sources such as `corsweb2024/src/content/blog/ja/*.md`.
 
 Each fetcher carries its own User-Agent string and rate-limit policy.
 
 Acceptance:
 
-- Scenario test fetches one article from each of {note, zenn, qiita, rss} and produces `tmp/source_fetch/{name}.json`.
+- Scenario test fetches historical user/account material from {note, zenn, qiita, rss, github}; it must prove that Zenn and Qiita return multiple Cloudia articles with body text, and that Cor.inc blog style analysis uses GitHub Markdown because RSS only contains short descriptions.
 - The note.com host check moves out of the application service into the `note` fetcher only; other hosts route to other fetchers.
 
 ### B3 — Format-specific prompt templates and validators

--- a/docs/validation/issue-22-source-fetchers-2026-05-02.md
+++ b/docs/validation/issue-22-source-fetchers-2026-05-02.md
@@ -4,7 +4,9 @@ Date: 2026-05-02
 
 ## Scope
 
-Validate [#22](https://github.com/terisuke/note_maker/issues/22): route source acquisition beyond note.com to Zenn, Qiita, RSS/Atom, and generic HTML while keeping normal tests offline.
+Validate [#22](https://github.com/terisuke/note_maker/issues/22): route source acquisition beyond note.com to Zenn, Qiita, RSS/Atom, generic HTML, and GitHub-backed Markdown while keeping normal tests offline.
+
+Correction note: the first validation pass only proved one current item per source. That was not enough for Cloudia/Zenn/Qiita/Cor blog style analysis. This document now records the 2026-05-02 corrective validation against historical user/account sources with a high limit and body-length checks.
 
 ## Current source facts checked
 
@@ -12,7 +14,10 @@ Validate [#22](https://github.com/terisuke/note_maker/issues/22): route source a
 - Qiita API v2 documents unauthenticated access as limited to `60` requests per hour per IP address, so the fetcher uses one request per user-list scenario and no polling loop.
 - Zenn's official RSS article documents user feeds as `https://zenn.dev/ユーザー名/feed`.
 - Zenn's official RSS article documents `?all=1` for including all public posts instead of the default limited feed, so the Zenn fetcher uses that query for user lists.
+- Zenn user RSS is a list source. The implementation now expands each feed item URL through the article page's embedded Next.js data so style analysis receives full article body text, not feed summaries.
 - RSS/Atom parsing is implemented through standard XML feeds, with RSS 2.0 item fields and Atom entries handled in one `RSSFetcher`.
+- GitHub's repository contents API can read public repository files without authentication. Cor.inc blog Markdown is therefore fetched from `Cor-Incorporated/corsweb2024/src/content/blog/ja/*.md`, preserving Astro frontmatter and body Markdown.
+- Cor.inc `https://cor-jp.com/rss.xml` is useful for discovery and ordering, but it only contains short descriptions. The canonical full body source for company blog style analysis is GitHub Markdown.
 
 ## Implementation
 
@@ -23,7 +28,9 @@ Validate [#22](https://github.com/terisuke/note_maker/issues/22): route source a
   - `qiita:<user>` and qiita.com URLs go to Qiita API v2 fetchers.
   - `rss:<url>` and feed-like URLs go to RSS/Atom parsing.
   - `html:<url>` and unknown article URLs go to semantic HTML extraction.
+  - `github:<owner>/<repo>/<path>` and GitHub/blob/raw URLs go to GitHub repository Markdown fetching.
 - `AnalyzeAuthorStyleHandler` and the legacy article-generation handler now use the router through an adapter that still satisfies the existing `FetchArticle` / `FetchUserLatestArticles` application interface.
+- `cmd/scenario/source_fetch` accepts `SOURCE_FETCH_LIMIT`; the default is now multi-item validation rather than a one-item smoke test.
 
 ## Scenario
 
@@ -31,28 +38,32 @@ Command:
 
 ```bash
 RUN_SOURCE_FETCH_SCENARIO=1 \
-SCENARIO_OUTPUT_DIR=tmp/source_fetch_issue22 \
+SCENARIO_OUTPUT_DIR=tmp/source_fetch_cloudia_history \
+SOURCE_FETCH_LIMIT=100 \
 SOURCE_FETCH_NOTE=note:cor_instrument \
-SOURCE_FETCH_ZENN=zenn:zenn \
-SOURCE_FETCH_QIITA=qiita:Qiita \
-SOURCE_FETCH_RSS=rss:https://zenn.dev/zenn/feed \
+SOURCE_FETCH_ZENN=zenn:cloudia \
+SOURCE_FETCH_QIITA=qiita:Cloudia_Cor_Inc \
+SOURCE_FETCH_RSS=rss:https://cor-jp.com/rss.xml \
+SOURCE_FETCH_GITHUB=github:Cor-Incorporated/corsweb2024/src/content/blog/ja \
 go run ./cmd/scenario/source_fetch
 ```
 
 Result:
 
-| Source | Selector | Articles | Elapsed | Output |
-|---|---|---:|---:|---|
-| Qiita | `qiita:Qiita` | 1 | 0.68s | `tmp/source_fetch_issue22/qiita.json` |
-| RSS | `rss:https://zenn.dev/zenn/feed` | 1 | 0.18s | `tmp/source_fetch_issue22/rss.json` |
-| note | `note:cor_instrument` | 1 | 0.66s | `tmp/source_fetch_issue22/note.json` |
-| Zenn | `zenn:zenn` | 1 | 0.19s | `tmp/source_fetch_issue22/zenn.json` |
+| Source | Selector | Articles | Elapsed | Avg content length | Output |
+|---|---|---:|---:|---:|---|
+| note | `note:cor_instrument` | 20 | 6.99s | not part of this corrective check | `tmp/source_fetch_cloudia_history/note.json` |
+| Zenn | `zenn:cloudia` | 7 | 1.08s | 4,139 chars | `tmp/source_fetch_cloudia_history/zenn.json` |
+| Qiita | `qiita:Cloudia_Cor_Inc` | 12 | 0.28s | 3,274 chars | `tmp/source_fetch_cloudia_history/qiita.json` |
+| Cor RSS | `rss:https://cor-jp.com/rss.xml` | 10 | 0.16s | 69 chars | `tmp/source_fetch_cloudia_history/rss.json` |
+| Cor GitHub Markdown | `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` | 10 | 0.62s | 4,218 chars | `tmp/source_fetch_cloudia_history/github.json` |
 
-Recent-source check:
+Historical-source check:
 
-- Qiita returned `Qiita アップデートサマリー - 2026年4月`, which is inside the requested recent two-month window from 2026-05-02.
-- Zenn/RSS returned Zenn official content from the current public feed path.
-- note returned the latest public `cor_instrument` article available through the existing note source path.
+- Zenn `cloudia` returned all 7 public feed items from `?all=1`, with article-page body extraction.
+- Qiita `Cloudia_Cor_Inc` returned 12 public user items through the official user items API, with Markdown `body`.
+- Cor RSS returned 10 public feed items but only short descriptions, confirming that RSS alone is insufficient for company-blog style analysis.
+- Cor GitHub Markdown returned 10 Japanese blog Markdown files with frontmatter and full body content, confirming this is the practical source for company-blog output mode.
 
 ## Tests
 
@@ -65,4 +76,5 @@ Focused source tests cover:
 - RSS 2.0 `content:encoded` parsing.
 - Atom entry parsing.
 - explicit `zenn:`, `qiita:`, and `rss:` selector routing.
-- host-based routing for note.com, zenn.dev, qiita.com, RSS-like URLs, and generic HTML.
+- explicit `github:` selector routing.
+- host-based routing for note.com, zenn.dev, qiita.com, GitHub/blob/raw URLs, RSS-like URLs, and generic HTML.

--- a/internal/domain/source/source.go
+++ b/internal/domain/source/source.go
@@ -12,11 +12,12 @@ import (
 type Kind string
 
 const (
-	KindNote  Kind = "note"
-	KindZenn  Kind = "zenn"
-	KindQiita Kind = "qiita"
-	KindRSS   Kind = "rss"
-	KindHTML  Kind = "html"
+	KindNote   Kind = "note"
+	KindZenn   Kind = "zenn"
+	KindQiita  Kind = "qiita"
+	KindRSS    Kind = "rss"
+	KindHTML   Kind = "html"
+	KindGitHub Kind = "github"
 )
 
 // Ref points to a public author, feed, or article.
@@ -29,7 +30,7 @@ type Ref struct {
 // Validate rejects empty or unknown references.
 func (r Ref) Validate() error {
 	switch r.Kind {
-	case KindNote, KindZenn, KindQiita:
+	case KindNote, KindZenn, KindQiita, KindGitHub:
 		if strings.TrimSpace(r.Ref) == "" && strings.TrimSpace(r.URL) == "" {
 			return fmt.Errorf("%s source requires ref or url", r.Kind)
 		}

--- a/internal/infrastructure/source/github.go
+++ b/internal/infrastructure/source/github.go
@@ -1,0 +1,285 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
+)
+
+// GitHubMarkdownFetcher reads Markdown files from public GitHub repositories.
+// It is used for site-backed blogs such as corsweb2024 where the repository is
+// the canonical source for frontmatter and Markdown body.
+type GitHubMarkdownFetcher struct {
+	client *http.Client
+}
+
+// NewGitHubMarkdownFetcher creates a GitHub Contents API fetcher.
+func NewGitHubMarkdownFetcher(client *http.Client) *GitHubMarkdownFetcher {
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &GitHubMarkdownFetcher{client: client}
+}
+
+// FetchList fetches Markdown files from a repository directory.
+func (f *GitHubMarkdownFetcher) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int) ([]sourcedomain.ArticleSnapshot, error) {
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	repoRef, err := parseGitHubRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := f.listContents(ctx, repoRef)
+	if err != nil {
+		return nil, err
+	}
+	snapshots := make([]sourcedomain.ArticleSnapshot, 0, min(limit, len(entries)))
+	for _, entry := range entries {
+		if entry.Type != "file" || !isMarkdownPath(entry.Path) {
+			continue
+		}
+		snapshot, err := f.snapshotFromDownload(ctx, repoRef, entry)
+		if err != nil {
+			continue
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	sort.SliceStable(snapshots, func(i, j int) bool {
+		left := snapshots[i].PublishedAt
+		right := snapshots[j].PublishedAt
+		if !left.IsZero() || !right.IsZero() {
+			return left.After(right)
+		}
+		return snapshots[i].Title < snapshots[j].Title
+	})
+	if len(snapshots) > limit {
+		snapshots = snapshots[:limit]
+	}
+	return snapshots, nil
+}
+
+// FetchArticle fetches one Markdown file by GitHub URL or github: ref.
+func (f *GitHubMarkdownFetcher) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+	repoRef, err := parseGitHubRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	if !isMarkdownPath(repoRef.Path) {
+		return nil, fmt.Errorf("github article path must be markdown: %s", repoRef.Path)
+	}
+	entry := githubContentEntry{
+		Name:        path.Base(repoRef.Path),
+		Path:        repoRef.Path,
+		Type:        "file",
+		DownloadURL: rawGitHubURL(repoRef),
+		HTMLURL:     githubBlobURL(repoRef),
+	}
+	snapshot, err := f.snapshotFromDownload(ctx, repoRef, entry)
+	if err != nil {
+		return nil, err
+	}
+	return &snapshot, nil
+}
+
+func (f *GitHubMarkdownFetcher) listContents(ctx context.Context, ref githubRef) ([]githubContentEntry, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s",
+		url.PathEscape(ref.Owner),
+		url.PathEscape(ref.Repo),
+		strings.TrimLeft(ref.Path, "/"),
+		url.QueryEscape(ref.Branch),
+	)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create github contents request: %w", err)
+	}
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("Accept", "application/vnd.github+json")
+	response, err := f.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch github contents: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch github contents: unexpected status %s", response.Status)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read github contents: %w", err)
+	}
+	var entries []githubContentEntry
+	if err := json.Unmarshal(body, &entries); err == nil {
+		return entries, nil
+	}
+	var entry githubContentEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return nil, fmt.Errorf("decode github contents: %w", err)
+	}
+	return []githubContentEntry{entry}, nil
+}
+
+func (f *GitHubMarkdownFetcher) snapshotFromDownload(ctx context.Context, repoRef githubRef, entry githubContentEntry) (sourcedomain.ArticleSnapshot, error) {
+	downloadURL := strings.TrimSpace(entry.DownloadURL)
+	if downloadURL == "" {
+		downloadURL = rawGitHubURL(githubRef{Owner: repoRef.Owner, Repo: repoRef.Repo, Branch: repoRef.Branch, Path: entry.Path})
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return sourcedomain.ArticleSnapshot{}, fmt.Errorf("create github raw request: %w", err)
+	}
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("Accept", "text/markdown, text/plain;q=0.9, */*;q=0.8")
+	response, err := f.client.Do(request)
+	if err != nil {
+		return sourcedomain.ArticleSnapshot{}, fmt.Errorf("fetch github raw: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return sourcedomain.ArticleSnapshot{}, fmt.Errorf("fetch github raw: unexpected status %s", response.Status)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return sourcedomain.ArticleSnapshot{}, fmt.Errorf("read github raw: %w", err)
+	}
+	content := strings.TrimSpace(string(body))
+	if content == "" {
+		return sourcedomain.ArticleSnapshot{}, fmt.Errorf("github markdown was empty: %s", entry.Path)
+	}
+	metadata, markdown := splitFrontmatter(content)
+	title := firstNonEmpty(metadata["title"], firstMarkdownHeading(markdown), strings.TrimSuffix(path.Base(entry.Path), path.Ext(entry.Path)))
+	publishedAt := parseFeedTime(metadata["pubDate"])
+	htmlURL := firstNonEmpty(entry.HTMLURL, githubBlobURL(githubRef{Owner: repoRef.Owner, Repo: repoRef.Repo, Branch: repoRef.Branch, Path: entry.Path}))
+	return sourcedomain.ArticleSnapshot{
+		ID:          entry.Path,
+		Kind:        sourcedomain.KindGitHub,
+		URL:         htmlURL,
+		Title:       normalizeWhitespace(unquoteYAMLScalar(title)),
+		Content:     content,
+		PublishedAt: publishedAt,
+		UpdatedAt:   publishedAt,
+		FetchedAt:   time.Now().UTC(),
+	}, nil
+}
+
+func parseGitHubRef(ref sourcedomain.Ref) (githubRef, error) {
+	if strings.TrimSpace(ref.URL) != "" {
+		return parseGitHubURL(ref.URL)
+	}
+	value := strings.Trim(strings.TrimSpace(ref.Ref), "/")
+	parts := strings.Split(value, "/")
+	if len(parts) < 3 {
+		return githubRef{}, fmt.Errorf("github ref must be owner/repo/path")
+	}
+	branch := "main"
+	repoPathParts := parts[2:]
+	if repo, branchValue, ok := strings.Cut(parts[1], "@"); ok {
+		parts[1] = repo
+		branch = branchValue
+	}
+	return githubRef{Owner: parts[0], Repo: parts[1], Branch: branch, Path: strings.Join(repoPathParts, "/")}, nil
+}
+
+func parseGitHubURL(rawURL string) (githubRef, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return githubRef{}, fmt.Errorf("parse github url: %w", err)
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	host := strings.ToLower(parsed.Hostname())
+	switch {
+	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
+		if len(parts) < 5 || (parts[2] != "blob" && parts[2] != "tree") {
+			return githubRef{}, fmt.Errorf("github url must be /owner/repo/blob-or-tree/branch/path")
+		}
+		return githubRef{Owner: parts[0], Repo: parts[1], Branch: parts[3], Path: strings.Join(parts[4:], "/")}, nil
+	case host == "raw.githubusercontent.com":
+		if len(parts) < 4 {
+			return githubRef{}, fmt.Errorf("raw github url must be /owner/repo/branch/path")
+		}
+		return githubRef{Owner: parts[0], Repo: parts[1], Branch: parts[2], Path: strings.Join(parts[3:], "/")}, nil
+	default:
+		return githubRef{}, fmt.Errorf("unsupported github host %s", parsed.Hostname())
+	}
+}
+
+func rawGitHubURL(ref githubRef) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", ref.Owner, ref.Repo, ref.Branch, strings.TrimLeft(ref.Path, "/"))
+}
+
+func githubBlobURL(ref githubRef) string {
+	return fmt.Sprintf("https://github.com/%s/%s/blob/%s/%s", ref.Owner, ref.Repo, ref.Branch, strings.TrimLeft(ref.Path, "/"))
+}
+
+func isMarkdownPath(value string) bool {
+	lower := strings.ToLower(value)
+	return strings.HasSuffix(lower, ".md") || strings.HasSuffix(lower, ".mdx")
+}
+
+func splitFrontmatter(content string) (map[string]string, string) {
+	metadata := map[string]string{}
+	normalized := strings.ReplaceAll(strings.ReplaceAll(content, "\r\n", "\n"), "\r", "\n")
+	if !strings.HasPrefix(normalized, "---\n") {
+		return metadata, content
+	}
+	rest := strings.TrimPrefix(normalized, "---\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return metadata, content
+	}
+	frontmatter := rest[:end]
+	body := strings.TrimSpace(rest[end+len("\n---"):])
+	for _, line := range strings.Split(frontmatter, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		metadata[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return metadata, body
+}
+
+func unquoteYAMLScalar(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, `"'`)
+	return value
+}
+
+func firstMarkdownHeading(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "# "))
+		}
+	}
+	return ""
+}
+
+type githubRef struct {
+	Owner  string
+	Repo   string
+	Path   string
+	Branch string
+}
+
+type githubContentEntry struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Type        string `json:"type"`
+	DownloadURL string `json:"download_url"`
+	HTMLURL     string `json:"html_url"`
+}

--- a/internal/infrastructure/source/router.go
+++ b/internal/infrastructure/source/router.go
@@ -15,11 +15,12 @@ import (
 
 // Router dispatches public source refs to concrete fetchers.
 type Router struct {
-	note  *notenote.Fetcher
-	zenn  *ZennFetcher
-	qiita *QiitaFetcher
-	rss   *RSSFetcher
-	html  *HTMLFetcher
+	note   *notenote.Fetcher
+	zenn   *ZennFetcher
+	qiita  *QiitaFetcher
+	rss    *RSSFetcher
+	html   *HTMLFetcher
+	github *GitHubMarkdownFetcher
 }
 
 // NewRouter creates a source router with shared HTTP settings.
@@ -33,11 +34,12 @@ func NewRouterWithClient(client *http.Client) *Router {
 		client = &http.Client{Timeout: 20 * time.Second}
 	}
 	return &Router{
-		note:  notenote.NewFetcherWithClient(client),
-		zenn:  NewZennFetcher(client),
-		qiita: NewQiitaFetcher(client),
-		rss:   NewRSSFetcher(client),
-		html:  NewHTMLFetcher(client),
+		note:   notenote.NewFetcherWithClient(client),
+		zenn:   NewZennFetcher(client),
+		qiita:  NewQiitaFetcher(client),
+		rss:    NewRSSFetcher(client),
+		html:   NewHTMLFetcher(client),
+		github: NewGitHubMarkdownFetcher(client),
 	}
 }
 
@@ -56,6 +58,8 @@ func (r *Router) FetchList(ctx context.Context, ref sourcedomain.Ref, limit int)
 		return r.rss.FetchList(ctx, ref, limit)
 	case sourcedomain.KindHTML:
 		return r.html.FetchList(ctx, ref, limit)
+	case sourcedomain.KindGitHub:
+		return r.github.FetchList(ctx, ref, limit)
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", ref.Kind)
 	}
@@ -80,6 +84,8 @@ func (r *Router) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourc
 		return r.rss.FetchArticle(ctx, ref)
 	case sourcedomain.KindHTML:
 		return r.html.FetchArticle(ctx, ref)
+	case sourcedomain.KindGitHub:
+		return r.github.FetchArticle(ctx, ref)
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", ref.Kind)
 	}
@@ -111,7 +117,8 @@ func (f *AuthorStyleFetcher) FetchArticle(ctx context.Context, articleURL string
 }
 
 // FetchUserLatestArticles supports explicit refs such as zenn:cloudia,
-// qiita:Cloudia_Cor_Inc, rss:https://example.com/feed.xml, and legacy note usernames.
+// qiita:Cloudia_Cor_Inc, rss:https://example.com/feed.xml,
+// github:owner/repo/path, and legacy note usernames.
 func (f *AuthorStyleFetcher) FetchUserLatestArticles(ctx context.Context, username string, limit int) ([]articledomain.Article, error) {
 	snapshots, err := f.router.FetchList(ctx, RefFromSelector(username), limit)
 	if err != nil {
@@ -147,6 +154,8 @@ func RefFromURL(rawURL string) sourcedomain.Ref {
 		return sourcedomain.Ref{Kind: sourcedomain.KindZenn, URL: rawURL}
 	case host == "qiita.com" || strings.HasSuffix(host, ".qiita.com"):
 		return sourcedomain.Ref{Kind: sourcedomain.KindQiita, URL: rawURL}
+	case host == "github.com" || strings.HasSuffix(host, ".github.com") || host == "raw.githubusercontent.com":
+		return sourcedomain.Ref{Kind: sourcedomain.KindGitHub, URL: rawURL}
 	case strings.Contains(strings.ToLower(parsed.Path), "rss") || strings.Contains(strings.ToLower(parsed.Path), "feed") || strings.HasSuffix(strings.ToLower(parsed.Path), ".xml"):
 		return sourcedomain.Ref{Kind: sourcedomain.KindRSS, URL: rawURL}
 	default:
@@ -181,6 +190,8 @@ func parseKindSelector(selector string) (sourcedomain.Ref, bool) {
 		return sourcedomain.Ref{Kind: sourcedomain.KindRSS, URL: value}, true
 	case "html":
 		return sourcedomain.Ref{Kind: sourcedomain.KindHTML, URL: value}, true
+	case "github":
+		return sourcedomain.Ref{Kind: sourcedomain.KindGitHub, Ref: strings.Trim(value, "/")}, true
 	default:
 		return sourcedomain.Ref{}, false
 	}

--- a/internal/infrastructure/source/rss_test.go
+++ b/internal/infrastructure/source/rss_test.go
@@ -67,10 +67,21 @@ func TestAuthorStyleFetcherRoutesExplicitSources(t *testing.T) {
 				t.Fatalf("zenn feed should request all=1, got %s", r.URL.RawQuery)
 			}
 			_, _ = w.Write([]byte(`<?xml version="1.0"?><rss><channel><item><title>Zenn</title><link>https://zenn.dev/zenn-user/articles/a</link><description><![CDATA[<p>Zenn本文</p>]]></description></item></channel></rss>`))
+		case "/zenn-user/articles/a":
+			_, _ = w.Write([]byte(`<html><head><meta property="og:title" content="Zenn"></head><body><article><h1>Zenn</h1><p>Zenn記事ページ本文</p></article></body></html>`))
 		case "/api/v2/users/qiita-user/items":
 			_, _ = w.Write([]byte(`[{"id":"abc","url":"https://qiita.com/qiita-user/items/abc","title":"Qiita","body":"# Qiita本文","created_at":"2026-05-02T00:00:00+09:00","updated_at":"2026-05-02T00:00:00+09:00"}]`))
 		case "/feed.xml":
 			_, _ = w.Write([]byte(`<?xml version="1.0"?><rss><channel><item><title>RSS</title><link>https://example.com/rss</link><description><![CDATA[<p>RSS本文</p>]]></description></item></channel></rss>`))
+		case "/repos/owner/repo/contents/src/content/blog/ja":
+			_, _ = w.Write([]byte(`[{"name":"post.md","path":"src/content/blog/ja/post.md","type":"file","download_url":"https://raw.githubusercontent.com/owner/repo/main/src/content/blog/ja/post.md","html_url":"https://github.com/owner/repo/blob/main/src/content/blog/ja/post.md"}]`))
+		case "/owner/repo/main/src/content/blog/ja/post.md":
+			_, _ = w.Write([]byte(`---
+title: "GitHub記事"
+pubDate: 2026-05-02
+---
+
+GitHub Markdown本文`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -79,16 +90,17 @@ func TestAuthorStyleFetcherRoutesExplicitSources(t *testing.T) {
 
 	fetcher := NewAuthorStyleFetcherWithClient(mappedClient(server.URL))
 	cases := map[string]string{
-		"zenn:zenn-user":         "Zenn本文",
-		"qiita:qiita-user":       "# Qiita本文",
-		"rss:https://x/feed.xml": "RSS本文",
+		"zenn:zenn-user":                        "Zenn\n\nZenn記事ページ本文",
+		"qiita:qiita-user":                      "# Qiita本文",
+		"rss:https://x/feed.xml":                "RSS本文",
+		"github:owner/repo/src/content/blog/ja": `title: "GitHub記事"`,
 	}
 	for selector, wantContent := range cases {
 		articles, err := fetcher.FetchUserLatestArticles(context.Background(), selector, 3)
 		if err != nil {
 			t.Fatalf("%s: fetch latest: %v", selector, err)
 		}
-		if len(articles) != 1 || articles[0].Content != wantContent {
+		if len(articles) != 1 || !strings.Contains(articles[0].Content, wantContent) {
 			t.Fatalf("%s: unexpected articles: %#v", selector, articles)
 		}
 	}
@@ -96,11 +108,12 @@ func TestAuthorStyleFetcherRoutesExplicitSources(t *testing.T) {
 
 func TestRefFromURLRoutesKnownHosts(t *testing.T) {
 	tests := map[string]sourcedomain.Kind{
-		"https://note.com/user/n/n1":         sourcedomain.KindNote,
-		"https://zenn.dev/user/articles/abc": sourcedomain.KindZenn,
-		"https://qiita.com/user/items/abc":   sourcedomain.KindQiita,
-		"https://example.com/rss.xml":        sourcedomain.KindRSS,
-		"https://example.com/blog/post":      sourcedomain.KindHTML,
+		"https://note.com/user/n/n1":            sourcedomain.KindNote,
+		"https://zenn.dev/user/articles/abc":    sourcedomain.KindZenn,
+		"https://qiita.com/user/items/abc":      sourcedomain.KindQiita,
+		"https://example.com/rss.xml":           sourcedomain.KindRSS,
+		"https://github.com/o/r/blob/main/a.md": sourcedomain.KindGitHub,
+		"https://example.com/blog/post":         sourcedomain.KindHTML,
 	}
 	for rawURL, want := range tests {
 		if got := RefFromURL(rawURL).Kind; got != want {

--- a/internal/infrastructure/source/text.go
+++ b/internal/infrastructure/source/text.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"strings"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 )
@@ -58,4 +59,13 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
 }

--- a/internal/infrastructure/source/zenn.go
+++ b/internal/infrastructure/source/zenn.go
@@ -2,11 +2,14 @@ package source
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/PuerkitoBio/goquery"
 	sourcedomain "github.com/teradakousuke/note_maker/internal/domain/source"
 )
 
@@ -42,22 +45,92 @@ func (f *ZennFetcher) FetchList(ctx context.Context, ref sourcedomain.Ref, limit
 		return nil, fmt.Errorf("zenn user ref is required")
 	}
 	feedURL := fmt.Sprintf("https://zenn.dev/%s/feed?all=1", url.PathEscape(user))
-	snapshots, err := f.rss.FetchList(ctx, sourcedomain.Ref{Kind: sourcedomain.KindZenn, Ref: user, URL: feedURL}, limit)
+	feedSnapshots, err := f.rss.FetchList(ctx, sourcedomain.Ref{Kind: sourcedomain.KindZenn, Ref: user, URL: feedURL}, limit)
 	if err != nil {
 		return nil, err
 	}
-	for i := range snapshots {
-		snapshots[i].Kind = sourcedomain.KindZenn
+	snapshots := make([]sourcedomain.ArticleSnapshot, 0, len(feedSnapshots))
+	for _, feedSnapshot := range feedSnapshots {
+		feedSnapshot.Kind = sourcedomain.KindZenn
+		article, err := f.FetchArticle(ctx, sourcedomain.Ref{Kind: sourcedomain.KindZenn, URL: feedSnapshot.URL})
+		if err != nil || article == nil || strings.TrimSpace(article.Content) == "" {
+			snapshots = append(snapshots, feedSnapshot)
+			continue
+		}
+		article.ID = firstNonEmpty(feedSnapshot.ID, article.ID)
+		article.Title = firstNonEmpty(feedSnapshot.Title, article.Title)
+		article.PublishedAt = firstNonZeroTime(feedSnapshot.PublishedAt, article.PublishedAt)
+		article.UpdatedAt = firstNonZeroTime(feedSnapshot.UpdatedAt, article.UpdatedAt)
+		article.FetchedAt = firstNonZeroTime(article.FetchedAt, feedSnapshot.FetchedAt)
+		snapshots = append(snapshots, *article)
 	}
 	return snapshots, nil
 }
 
 // FetchArticle fetches one Zenn article page.
 func (f *ZennFetcher) FetchArticle(ctx context.Context, ref sourcedomain.Ref) (*sourcedomain.ArticleSnapshot, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSpace(ref.URL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create zenn article request: %w", err)
+	}
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	response, err := f.html.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch zenn article: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch zenn article: unexpected status %s", response.Status)
+	}
+	doc, err := goquery.NewDocumentFromReader(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parse zenn article html: %w", err)
+	}
+	title := firstNonEmpty(
+		selectionAttr(doc, `meta[property="og:title"]`, "content"),
+		selectionText(doc, "h1"),
+		selectionText(doc, "title"),
+	)
+	nextData := zennNextDataFromDocument(doc)
+	if strings.TrimSpace(nextData.Props.PageProps.Article.BodyHTML) != "" {
+		content := htmlToParagraphText(nextData.Props.PageProps.Article.BodyHTML)
+		if content != "" {
+			return &sourcedomain.ArticleSnapshot{
+				ID:        ref.URL,
+				Kind:      sourcedomain.KindZenn,
+				URL:       ref.URL,
+				Title:     normalizeWhitespace(firstNonEmpty(nextData.Props.PageProps.Article.Title, title)),
+				Content:   content,
+				FetchedAt: time.Now().UTC(),
+			}, nil
+		}
+	}
 	article, err := f.html.FetchArticle(ctx, sourcedomain.Ref{Kind: sourcedomain.KindHTML, URL: ref.URL})
 	if err != nil {
 		return nil, err
 	}
 	article.Kind = sourcedomain.KindZenn
 	return article, nil
+}
+
+func zennNextDataFromDocument(doc *goquery.Document) zennNextData {
+	var data zennNextData
+	raw := strings.TrimSpace(doc.Find("script#__NEXT_DATA__").First().Text())
+	if raw == "" {
+		return data
+	}
+	_ = json.Unmarshal([]byte(raw), &data)
+	return data
+}
+
+type zennNextData struct {
+	Props struct {
+		PageProps struct {
+			Article struct {
+				Title    string `json:"title"`
+				BodyHTML string `json:"bodyHtml"`
+			} `json:"article"`
+		} `json:"pageProps"`
+	} `json:"props"`
 }


### PR DESCRIPTION
## Summary
- expands Zenn list fetching from RSS summaries into full article-body extraction via article page data
- adds github: source support for Cor.inc blog Markdown under corsweb2024/src/content/blog/ja
- updates the source-fetch scenario to use configurable multi-item limits and Cloudia/Cor defaults
- updates ADR/implementation/validation docs with the corrective historical-source check

## Validation
- go test ./...
- RUN_SOURCE_FETCH_SCENARIO=1 SCENARIO_OUTPUT_DIR=tmp/source_fetch_cloudia_history SOURCE_FETCH_LIMIT=100 SOURCE_FETCH_NOTE=note:cor_instrument SOURCE_FETCH_ZENN=zenn:cloudia SOURCE_FETCH_QIITA=qiita:Cloudia_Cor_Inc SOURCE_FETCH_RSS=rss:https://cor-jp.com/rss.xml SOURCE_FETCH_GITHUB=github:Cor-Incorporated/corsweb2024/src/content/blog/ja go run ./cmd/scenario/source_fetch

## Live results on 2026-05-02
- Zenn cloudia: 7 articles, avg 4,139 chars
- Qiita Cloudia_Cor_Inc: 12 articles, avg 3,274 chars
- Cor RSS: 10 items, avg 69 chars, discovery only
- Cor GitHub Markdown: 10 articles, avg 4,218 chars

Closes #22