### PR TITLE
Implement persona and format aware question templates

### DIFF
--- a/cmd/scenario/media_matrix/main.go
+++ b/cmd/scenario/media_matrix/main.go
@@ -1,0 +1,645 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	draftapp "github.com/teradakousuke/note_maker/internal/application/draft"
+	authordomain "github.com/teradakousuke/note_maker/internal/domain/author"
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
+)
+
+const defaultOutputDir = "tmp/media_matrix"
+
+var expectedSourceSelectors = []string{
+	"note:cor_instrument",
+	"zenn:cloudia",
+	"qiita:Cloudia_Cor_Inc",
+	"rss:https://cor-jp.com/rss.xml",
+	"github:Cor-Incorporated/corsweb2024/src/content/blog/ja",
+}
+
+type matrixCase struct {
+	ID                    string   `json:"id"`
+	PersonaID             string   `json:"persona_id"`
+	OutputFormatID        string   `json:"output_format_id"`
+	Medium                string   `json:"medium"`
+	Style                 string   `json:"style"`
+	Theme                 string   `json:"theme"`
+	OpeningEpisode        string   `json:"opening_episode"`
+	Reader                string   `json:"reader"`
+	ExpectedReaderAction  string   `json:"expected_reader_action"`
+	MustInclude           string   `json:"must_include"`
+	PersonalContext       string   `json:"personal_context"`
+	Exclusions            string   `json:"exclusions"`
+	TargetLengthStructure string   `json:"target_length_structure"`
+	ToneStance            string   `json:"tone_stance"`
+	SourceSelectors       []string `json:"source_selectors"`
+	PromptMustContain     []string `json:"prompt_must_contain"`
+}
+
+type matrixOutput struct {
+	GeneratedBy               string                  `json:"generated_by"`
+	OfflineOnly               bool                    `json:"offline_only"`
+	ExpectedSourceSelectors   []sourceSelectorResult  `json:"expected_source_selectors"`
+	FixedQuestionTemplate     []questionTemplateEntry `json:"fixed_question_template"`
+	ComposedQuestionTemplates []questionTemplateSet   `json:"composed_question_templates"`
+	Cases                     []caseResult            `json:"cases"`
+	ComparisonMetricsTemplate []string                `json:"comparison_metrics_template"`
+}
+
+type sourceSelectorResult struct {
+	Selector string `json:"selector"`
+	Found    bool   `json:"found"`
+	Persona  string `json:"persona,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+}
+
+type questionTemplateEntry struct {
+	ID          string `json:"id"`
+	Text        string `json:"text"`
+	Required    bool   `json:"required"`
+	TargetField string `json:"target_field"`
+}
+
+type questionTemplateSet struct {
+	PersonaID      string                  `json:"persona_id"`
+	OutputFormatID string                  `json:"output_format_id"`
+	Questions      []questionTemplateEntry `json:"questions"`
+}
+
+type caseResult struct {
+	ID                    string              `json:"id"`
+	PersonaID             string              `json:"persona_id"`
+	PersonaDisplayName    string              `json:"persona_display_name"`
+	OutputFormatID        string              `json:"output_format_id"`
+	OutputFormatName      string              `json:"output_format_name"`
+	Medium                string              `json:"medium"`
+	Style                 string              `json:"style"`
+	Theme                 string              `json:"theme"`
+	TargetLengthStructure string              `json:"target_length_structure"`
+	SourceSelectors       []string            `json:"source_selectors"`
+	BriefPath             string              `json:"brief_path"`
+	PromptPath            string              `json:"prompt_path"`
+	PromptChecks          []promptCheckResult `json:"prompt_checks"`
+	QuestionIDs           []string            `json:"question_ids"`
+	PlannedLLMCommand     string              `json:"planned_llm_command"`
+	ExpectedMetrics       []string            `json:"expected_metrics"`
+}
+
+type promptCheckResult struct {
+	Contains string `json:"contains"`
+	Passed   bool   `json:"passed"`
+}
+
+func main() {
+	outputDir := envOrDefault("SCENARIO_OUTPUT_DIR", defaultOutputDir)
+	briefDir := filepath.Join(outputDir, "briefs")
+	promptDir := filepath.Join(outputDir, "prompts")
+	for _, dir := range []string{outputDir, briefDir, promptDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			fatalf("create output dir %s: %v", dir, err)
+		}
+	}
+
+	personas := personadomain.DefaultRegistry()
+	formats := outputformat.DefaultRegistry()
+	sourceResults := verifyExpectedSources(personas.List())
+	questionTemplate := fixedQuestionTemplate()
+	composedTemplates := composedQuestionTemplates()
+	guide := scenarioGuide()
+
+	results := make([]caseResult, 0, len(plannedCases()))
+	for _, item := range plannedCases() {
+		persona, ok := personas.Get(item.PersonaID)
+		if !ok {
+			fatalf("%s references unknown persona %s", item.ID, item.PersonaID)
+		}
+		format, ok := formats.Get(item.OutputFormatID)
+		if !ok {
+			fatalf("%s references unknown output format %s", item.ID, item.OutputFormatID)
+		}
+		verifyCaseSources(item, sourceResults)
+		questions := briefdomain.ComposeFixedQuestions(item.PersonaID, item.OutputFormatID)
+		questionIDs := questionIDsFromQuestions(questions)
+
+		brief := buildBriefFromSession(item)
+		if brief.PersonaID != persona.ID || brief.OutputFormatID != format.ID {
+			fatalf("%s assembled mismatched brief persona/format", item.ID)
+		}
+		prompt := draftapp.BuildPromptForMode(guide, brief, persona, format)
+		checks := verifyPrompt(item, persona, format, prompt)
+
+		briefPath := filepath.Join(briefDir, item.ID+".json")
+		promptPath := filepath.Join(promptDir, item.ID+".prompt.md")
+		writeJSON(briefPath, brief)
+		writeFile(promptPath, prompt)
+
+		results = append(results, caseResult{
+			ID:                    item.ID,
+			PersonaID:             persona.ID,
+			PersonaDisplayName:    persona.DisplayName,
+			OutputFormatID:        format.ID,
+			OutputFormatName:      format.DisplayName,
+			Medium:                item.Medium,
+			Style:                 item.Style,
+			Theme:                 item.Theme,
+			TargetLengthStructure: item.TargetLengthStructure,
+			SourceSelectors:       append([]string(nil), item.SourceSelectors...),
+			BriefPath:             briefPath,
+			PromptPath:            promptPath,
+			PromptChecks:          checks,
+			QuestionIDs:           append([]string(nil), questionIDs...),
+			PlannedLLMCommand:     plannedLLMCommand(outputDir, item.ID, briefPath),
+			ExpectedMetrics: []string{
+				"elapsed_seconds",
+				"score",
+				"passed",
+				"verification_performed",
+				"verification_passed",
+				"runes",
+			},
+		})
+	}
+
+	matrix := matrixOutput{
+		GeneratedBy:               "cmd/scenario/media_matrix",
+		OfflineOnly:               true,
+		ExpectedSourceSelectors:   sourceResults,
+		FixedQuestionTemplate:     questionTemplate,
+		ComposedQuestionTemplates: composedTemplates,
+		Cases:                     results,
+		ComparisonMetricsTemplate: []string{
+			"case_id",
+			"phase",
+			"medium",
+			"style",
+			"target_length_structure",
+			"elapsed_seconds",
+			"score",
+			"verification_passed",
+			"output_path",
+		},
+	}
+	writeJSON(filepath.Join(outputDir, "matrix.json"), matrix)
+	writeFile(filepath.Join(outputDir, "cases.md"), casesMarkdown(results))
+
+	fmt.Printf("media matrix scenario completed\n")
+	fmt.Printf("offline_only=%v\n", matrix.OfflineOnly)
+	fmt.Printf("source_selectors=%d\n", len(matrix.ExpectedSourceSelectors))
+	fmt.Printf("question_template_ids=%d\n", len(matrix.FixedQuestionTemplate))
+	fmt.Printf("composed_templates=%d\n", len(matrix.ComposedQuestionTemplates))
+	fmt.Printf("cases=%d\n", len(matrix.Cases))
+	fmt.Printf("matrix=%s\n", filepath.Join(outputDir, "matrix.json"))
+	fmt.Printf("cases_markdown=%s\n", filepath.Join(outputDir, "cases.md"))
+}
+
+func verifyExpectedSources(personas []personadomain.Persona) []sourceSelectorResult {
+	available := map[string]sourceSelectorResult{}
+	for _, persona := range personas {
+		for _, source := range persona.Sources {
+			selector := sourceSelector(source)
+			if selector == "" {
+				continue
+			}
+			available[selector] = sourceSelectorResult{
+				Selector: selector,
+				Found:    true,
+				Persona:  persona.ID,
+				Kind:     source.Kind,
+			}
+		}
+	}
+
+	results := make([]sourceSelectorResult, 0, len(expectedSourceSelectors))
+	for _, selector := range expectedSourceSelectors {
+		result, ok := available[selector]
+		if !ok {
+			fatalf("expected source selector %s was not found in seeded personas", selector)
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func sourceSelector(source personadomain.AuthorSource) string {
+	kind := strings.TrimSpace(source.Kind)
+	ref := strings.TrimSpace(source.Ref)
+	url := strings.TrimSpace(source.URL)
+	switch kind {
+	case "note", "zenn", "qiita":
+		if ref == "" {
+			return ""
+		}
+		return kind + ":" + ref
+	case "rss":
+		if url == "" {
+			return ""
+		}
+		return "rss:" + strings.TrimSuffix(url, "/")
+	case "github":
+		return githubSelector(url)
+	default:
+		return ""
+	}
+}
+
+func githubSelector(url string) string {
+	const marker = "github.com/"
+	index := strings.Index(url, marker)
+	if index < 0 {
+		return ""
+	}
+	path := strings.TrimPrefix(url[index+len(marker):], "/")
+	path = strings.TrimSuffix(path, "/")
+	path = strings.Replace(path, "/tree/main/", "/", 1)
+	path = strings.Replace(path, "/tree/master/", "/", 1)
+	if path == "" {
+		return ""
+	}
+	return "github:" + path
+}
+
+func fixedQuestionTemplate() []questionTemplateEntry {
+	questions := briefdomain.FixedQuestions()
+	entries := make([]questionTemplateEntry, 0, len(questions))
+	requiredIDs := map[string]bool{
+		briefdomain.QuestionIDTheme:                 true,
+		briefdomain.QuestionIDReader:                true,
+		briefdomain.QuestionIDExpectedReaderAction:  true,
+		briefdomain.QuestionIDMustInclude:           true,
+		briefdomain.QuestionIDPersonalContext:       true,
+		briefdomain.QuestionIDTargetLengthStructure: true,
+		briefdomain.QuestionIDToneStance:            true,
+	}
+	seen := map[string]bool{}
+	for _, question := range questions {
+		seen[question.ID] = true
+		entries = append(entries, questionTemplateEntry{
+			ID:          question.ID,
+			Text:        question.Text,
+			Required:    question.Required,
+			TargetField: question.TargetField,
+		})
+	}
+	for id := range requiredIDs {
+		if !seen[id] {
+			fatalf("fixed question template missing %s", id)
+		}
+	}
+	return entries
+}
+
+func questionIDsFromTemplate(template []questionTemplateEntry) []string {
+	ids := make([]string, 0, len(template))
+	for _, question := range template {
+		ids = append(ids, question.ID)
+	}
+	return ids
+}
+
+func questionIDsFromQuestions(questions []briefdomain.ArticleQuestion) []string {
+	ids := make([]string, 0, len(questions))
+	for _, question := range questions {
+		ids = append(ids, question.ID)
+	}
+	return ids
+}
+
+func composedQuestionTemplates() []questionTemplateSet {
+	personas := []string{personadomain.IDTerisuke, personadomain.IDCloudia}
+	formats := []string{
+		outputformat.IDNoteArticle,
+		outputformat.IDMarkdownBlog,
+		outputformat.IDZennArticle,
+		outputformat.IDQiitaArticle,
+		outputformat.IDHomepageSection,
+	}
+	result := make([]questionTemplateSet, 0, len(personas)*len(formats))
+	for _, personaID := range personas {
+		for _, formatID := range formats {
+			questions := briefdomain.ComposeFixedQuestions(personaID, formatID)
+			if personaID == personadomain.IDCloudia && formatID == outputformat.IDZennArticle {
+				requireQuestion(questions, briefdomain.QuestionIDTargetStack)
+				requireQuestion(questions, briefdomain.QuestionIDCloudiaViewpoint)
+			}
+			result = append(result, questionTemplateSet{
+				PersonaID:      personaID,
+				OutputFormatID: formatID,
+				Questions:      questionTemplateEntries(questions),
+			})
+		}
+	}
+	return result
+}
+
+func questionTemplateEntries(questions []briefdomain.ArticleQuestion) []questionTemplateEntry {
+	entries := make([]questionTemplateEntry, 0, len(questions))
+	for _, question := range questions {
+		entries = append(entries, questionTemplateEntry{
+			ID:          question.ID,
+			Text:        question.Text,
+			Required:    question.Required,
+			TargetField: question.TargetField,
+		})
+	}
+	return entries
+}
+
+func requireQuestion(questions []briefdomain.ArticleQuestion, id string) {
+	for _, question := range questions {
+		if question.ID == id {
+			return
+		}
+	}
+	fatalf("composed question template missing %s", id)
+}
+
+func verifyCaseSources(item matrixCase, sources []sourceSelectorResult) {
+	available := map[string]bool{}
+	for _, source := range sources {
+		available[source.Selector] = source.Found
+	}
+	for _, selector := range item.SourceSelectors {
+		if !available[selector] {
+			fatalf("%s references unavailable source selector %s", item.ID, selector)
+		}
+	}
+}
+
+func buildBriefFromSession(item matrixCase) briefdomain.ArticleBrief {
+	session, err := briefdomain.NewArticleBriefSessionWithOptions(item.ID, "profile_media_matrix", item.PersonaID, item.OutputFormatID, "", briefdomain.ComposeFixedQuestions(item.PersonaID, item.OutputFormatID))
+	if err != nil {
+		fatalf("%s create brief session: %v", item.ID, err)
+	}
+	for _, question := range session.Questions {
+		if _, err := session.RecordAnswer(answerForQuestion(item, question.ID)); err != nil {
+			fatalf("%s answer %s: %v", item.ID, question.ID, err)
+		}
+	}
+	session.MarkDeepDiveSkipped()
+	brief, err := session.Complete()
+	if err != nil {
+		fatalf("%s complete brief session: %v", item.ID, err)
+	}
+	return brief
+}
+
+func answerForQuestion(item matrixCase, questionID string) string {
+	switch questionID {
+	case briefdomain.QuestionIDTheme:
+		return item.Theme
+	case briefdomain.QuestionIDOpeningEpisode:
+		return item.OpeningEpisode
+	case briefdomain.QuestionIDReader:
+		return item.Reader
+	case briefdomain.QuestionIDExpectedReaderAction:
+		return item.ExpectedReaderAction
+	case briefdomain.QuestionIDMustInclude:
+		return item.MustInclude
+	case briefdomain.QuestionIDPersonalContext:
+		return item.PersonalContext
+	case briefdomain.QuestionIDExclusions:
+		return item.Exclusions
+	case briefdomain.QuestionIDTargetLengthStructure:
+		return item.TargetLengthStructure
+	case briefdomain.QuestionIDToneStance:
+		return item.ToneStance
+	case briefdomain.QuestionIDStoryArc:
+		return "導入の違和感から、実践で見えた発見へ進み、読者が次に試す一歩で締める。"
+	case briefdomain.QuestionIDTargetStack:
+		return "Go 1.26、OpenAI互換API、Ollama/Evo X2、Markdown validator、ローカルシナリオCLI。"
+	case briefdomain.QuestionIDTechnicalProof:
+		return "実行コマンド、JSON出力、本文長、style score、verification結果を比較表に残す。"
+	case briefdomain.QuestionIDHomepageCTA:
+		return "問い合わせまたは技術相談への導線を置き、検証可能な発信基盤を短く伝える。"
+	case briefdomain.QuestionIDHomepageTrust:
+		return "実装済みの媒体別fetcher、format validator、シナリオ評価を根拠として示す。"
+	case briefdomain.QuestionIDCloudiaViewpoint:
+		return "クラウディア視点では、つまずきポイントを明るく拾い、初心者が一緒に試せる楽しさを入れる。"
+	default:
+		return ""
+	}
+}
+
+func verifyPrompt(item matrixCase, persona personadomain.Persona, format outputformat.OutputFormat, prompt string) []promptCheckResult {
+	mustContain := []string{
+		persona.DisplayName,
+		format.DisplayName,
+		item.Theme,
+		item.TargetLengthStructure,
+		"## 媒体別Markdownガイド",
+	}
+	mustContain = append(mustContain, item.PromptMustContain...)
+	results := make([]promptCheckResult, 0, len(mustContain))
+	for _, expected := range mustContain {
+		passed := strings.Contains(prompt, expected)
+		if !passed {
+			fatalf("%s prompt missing %q", item.ID, expected)
+		}
+		results = append(results, promptCheckResult{Contains: expected, Passed: passed})
+	}
+	return results
+}
+
+func plannedLLMCommand(outputDir, caseID, briefPath string) string {
+	return fmt.Sprintf("RUN_LOCAL_LLM_SCENARIO=1 ARTICLE_BRIEF_PATH=%s SCENARIO_OUTPUT_DIR=%s go run ./cmd/scenario/draft_generation", briefPath, filepath.Join(outputDir, "live", caseID))
+}
+
+func scenarioGuide() authordomain.WritingStyleGuide {
+	return authordomain.WritingStyleGuide{
+		ID:                   "guide_media_matrix",
+		ProfileID:            "profile_media_matrix",
+		Markdown:             "実体験、検証、読者への次の行動を媒体ごとに配分する。媒体が技術寄りなら手順と根拠を厚くし、noteやホームページでは読者の判断につながる文脈を厚くする。",
+		PreferredFirstPerson: "僕",
+		RecurringThemes:      []string{"AI", "検証", "発信", "実装"},
+		ParagraphRhythm:      "媒体ごとの読み方に合わせて段落密度を変える。",
+		SentenceRhythm:       "結論、根拠、次の行動が追える明快な文にする。",
+		HeadingGuidance:      "読者が期待する粒度で具体的な見出しにする。",
+		QuoteGuidance:        "引用は主張の転換点に限定する。",
+		OpeningPatterns:      []string{"具体的な違和感から始める", "検証結果から始める", "読者の作業場面から始める"},
+		ConclusionPatterns:   []string{"次の行動で締める", "検証の残課題で締める"},
+	}
+}
+
+func plannedCases() []matrixCase {
+	return []matrixCase{
+		{
+			ID:                    "terisuke_note_essay",
+			PersonaID:             personadomain.IDTerisuke,
+			OutputFormatID:        outputformat.IDNoteArticle,
+			Medium:                "note",
+			Style:                 "reflective essay",
+			Theme:                 "AI時代に手触りある創作を残す理由",
+			OpeningEpisode:        "ローカルLLMで下書きを速く作れた一方で、自分の違和感が抜けた原稿を読み返した場面",
+			Reader:                "AIで発信を増やしたいが、自分の言葉が薄まることを気にしている個人クリエイター",
+			ExpectedReaderAction:  "生成速度だけでなく、違和感や体験を先にメモしてからAIへ渡す",
+			MustInclude:           "創作の手触り、AIを使う前の素材メモ、下書き後の読み返し、読者への提案",
+			PersonalContext:       "音楽家、エンジニア、起業家として、便利さと表現の固有性の間で判断してきた経験",
+			Exclusions:            "AI万能論、根拠のない効率化断言、クラウディア口調",
+			TargetLengthStructure: "3000字前後。導入、違和感、背景、実践、読者への提案、結論",
+			ToneStance:            "内省を中心に、体験から技術との付き合い方へ接続する",
+			SourceSelectors:       []string{"note:cor_instrument"},
+			PromptMustContain:     []string{"note.com", "frontmatter、HTML"},
+		},
+		{
+			ID:                    "cor_blog_technical_report",
+			PersonaID:             personadomain.IDTerisuke,
+			OutputFormatID:        outputformat.IDMarkdownBlog,
+			Medium:                "cor-jp.com company blog",
+			Style:                 "technical report",
+			Theme:                 "ソース別スタイル分析を記事生成に接続する実装報告",
+			OpeningEpisode:        "note、Zenn、Qiita、RSS、GitHub Markdownを同じ検証表で見たときに本文密度の差が出た場面",
+			Reader:                "Cor.incの開発チームと、記事生成パイプラインの実装判断を知りたい技術読者",
+			ExpectedReaderAction:  "媒体ごとの入力ソースと検証指標を分けて、次の実装タスクを切れるようにする",
+			MustInclude:           "selector一覧、RSSとGitHub Markdownの役割差、format validator、runtime/score/verificationの比較観点",
+			PersonalContext:       "自社発信を継続可能な仕組みにするため、実装と編集判断を同じ場で扱っている背景",
+			Exclusions:            "未計測の性能比較、ライブLLM結果の捏造、読者が再現できない手順",
+			TargetLengthStructure: "2200-2800字。背景、実装、検証結果、リスク、次の実装",
+			ToneStance:            "会社ブログとして断定口調で、実装判断と検証可能性を明確にする",
+			SourceSelectors: []string{
+				"rss:https://cor-jp.com/rss.xml",
+				"github:Cor-Incorporated/corsweb2024/src/content/blog/ja",
+			},
+			PromptMustContain: []string{"corsweb2024", "category は ai / engineering / founder / lab", "実装判断"},
+		},
+		{
+			ID:                    "cor_blog_vision_sharing",
+			PersonaID:             personadomain.IDTerisuke,
+			OutputFormatID:        outputformat.IDMarkdownBlog,
+			Medium:                "cor-jp.com company blog",
+			Style:                 "vision sharing",
+			Theme:                 "生成AI時代のCor.inc発信基盤をどう育てるか",
+			OpeningEpisode:        "複数媒体の出力形式を揃えたことで、会社として何を蓄積すべきかが見えた場面",
+			Reader:                "Cor.incのメンバーと、会社の発信基盤に関心がある採用候補者",
+			ExpectedReaderAction:  "発信を個人技にせず、検証と再利用ができる社内資産として扱う",
+			MustInclude:           "会社ブログの役割、技術知見とビジョン共有の両立、媒体別ガイド、今後の運用方針",
+			PersonalContext:       "創業者として、プロダクト開発と発信を同じ学習ループに入れたい意図",
+			Exclusions:            "抽象的なスローガンだけの記事、採用広報だけに寄った表現",
+			TargetLengthStructure: "1600-2200字。課題、方針、運用、期待する行動",
+			ToneStance:            "社員へのビジョン共有として、落ち着いた断定と具体的な運用案を混ぜる",
+			SourceSelectors: []string{
+				"rss:https://cor-jp.com/rss.xml",
+				"github:Cor-Incorporated/corsweb2024/src/content/blog/ja",
+			},
+			PromptMustContain: []string{"社員へのビジョン共有", "lang は必ず \"ja\""},
+		},
+		{
+			ID:                    "cloudia_zenn_tutorial",
+			PersonaID:             personadomain.IDCloudia,
+			OutputFormatID:        outputformat.IDZennArticle,
+			Medium:                "Zenn",
+			Style:                 "tutorial",
+			Theme:                 "Goで媒体別プロンプトを検証する小さなCLIを作る",
+			OpeningEpisode:        "記事の出し先を変えたらfrontmatterや独自記法が混ざってエラーになった場面",
+			Reader:                "Goで記事生成ツールを作っていて、Zenn向け出力を安定させたい開発者",
+			ExpectedReaderAction:  "Zenn用のfrontmatter、topics、messageブロックを分けて検証する",
+			MustInclude:           "前提、実装手順、コード例、Zenn独自記法、つまずきポイント",
+			PersonalContext:       "クラウディアとして、初心者にも楽しく手順を追える技術解説にする",
+			Exclusions:            "Qiitaの:::note、HTML details、重い経営エッセイ調",
+			TargetLengthStructure: "1800-2400字。前提、実装、コード、確認、まとめ",
+			ToneStance:            "明るいチュートリアル。博多弁を少し混ぜ、コードと手順を主役にする",
+			SourceSelectors:       []string{"zenn:cloudia"},
+			PromptMustContain:     []string{":::message", "topics は5個以内", "クラウディア"},
+		},
+		{
+			ID:                    "cloudia_qiita_how_to",
+			PersonaID:             personadomain.IDCloudia,
+			OutputFormatID:        outputformat.IDQiitaArticle,
+			Medium:                "Qiita",
+			Style:                 "practical how-to",
+			Theme:                 "Qiita向け記事でdiffコードと注意書きを正しく出す",
+			OpeningEpisode:        "Zenn用の:::messageをQiita原稿に混ぜてしまい、レビューで修正が必要になった場面",
+			Reader:                "Qiitaに実装メモを投稿するエンジニア",
+			ExpectedReaderAction:  "Qiita形式のfrontmatter、diff_language、:::noteを使って再現手順を書く",
+			MustInclude:           "環境、手順、diff_go例、:::note warn、確認結果、参考リンク",
+			PersonalContext:       "クラウディアとして、試してすぐ動く実用手順に寄せる",
+			Exclusions:            "Zennの:::details、note風の長い内省、未検証のベストプラクティス断言",
+			TargetLengthStructure: "1400-2000字。環境、手順、コード差分、結果、補足",
+			ToneStance:            "実用重視の明るいハウツー。手順を短く区切る",
+			SourceSelectors:       []string{"qiita:Cloudia_Cor_Inc"},
+			PromptMustContain:     []string{":::note info", "diff_ruby", "Qiita"},
+		},
+		{
+			ID:                    "cor_homepage_section",
+			PersonaID:             personadomain.IDTerisuke,
+			OutputFormatID:        outputformat.IDHomepageSection,
+			Medium:                "homepage",
+			Style:                 "concise product section",
+			Theme:                 "媒体別の文章生成を事業サイトで短く伝える",
+			OpeningEpisode:        "記事生成の検証成果を、トップページの1セクションに圧縮する必要が出た場面",
+			Reader:                "Cor.incのサイト訪問者、協業候補、採用候補者",
+			ExpectedReaderAction:  "記事生成基盤が実装と発信の両方を支えることを理解し、問い合わせに進む",
+			MustInclude:           "媒体別最適化、検証可能な生成、会社サイト向けのCTA",
+			PersonalContext:       "Cor.incとして、AI実装と発信支援を同じ品質基準で扱う姿勢",
+			Exclusions:            "Markdown、frontmatter、コードブロック、長い説明",
+			TargetLengthStructure: "400-700字相当。h2、短い説明、CTA",
+			ToneStance:            "落ち着いた会社サイト文体。短く具体的に価値を伝える",
+			SourceSelectors: []string{
+				"rss:https://cor-jp.com/rss.xml",
+				"github:Cor-Incorporated/corsweb2024/src/content/blog/ja",
+			},
+			PromptMustContain: []string{"<section>", "MarkdownではなくHTML", "CTA"},
+		},
+	}
+}
+
+func casesMarkdown(cases []caseResult) string {
+	var builder strings.Builder
+	builder.WriteString("# Media matrix scenario\n\n")
+	builder.WriteString("Offline planned LLM run matrix. Live source and LLM commands are documented separately and are not run by this scenario.\n\n")
+	builder.WriteString("| Case | Persona | Format | Medium | Style | Target length | Sources |\n")
+	builder.WriteString("|---|---|---|---|---|---|---|\n")
+	for _, item := range cases {
+		builder.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %s | %s | %s | `%s` |\n",
+			item.ID,
+			item.PersonaID,
+			item.OutputFormatID,
+			escapeTable(item.Medium),
+			escapeTable(item.Style),
+			escapeTable(item.TargetLengthStructure),
+			strings.Join(item.SourceSelectors, "`, `"),
+		))
+	}
+	builder.WriteString("\n## Planned live LLM commands\n\n")
+	for _, item := range cases {
+		builder.WriteString("### " + item.ID + "\n\n")
+		builder.WriteString("```sh\n" + item.PlannedLLMCommand + "\n```\n\n")
+	}
+	return builder.String()
+}
+
+func escapeTable(value string) string {
+	return strings.ReplaceAll(value, "|", "\\|")
+}
+
+func writeJSON(path string, value any) {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		fatalf("encode %s: %v", path, err)
+	}
+	writeFile(path, string(encoded)+"\n")
+}
+
+func writeFile(path, content string) {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		fatalf("write %s: %v", path, err)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,6 +37,7 @@ func main() {
 	r.HandleFunc("/api/author-style/seed", handlers.SeedAuthorStyleHandler).Methods("POST")
 	r.HandleFunc("/api/author-style/analyze", handlers.AnalyzeAuthorStyleHandler).Methods("POST")
 	r.HandleFunc("/api/author-style/{id}", handlers.GetAuthorStyleHandler).Methods("GET")
+	r.HandleFunc("/api/brief-sessions/templates", handlers.GetBriefSessionTemplateHandler).Methods("GET")
 	r.HandleFunc("/api/brief-sessions", handlers.CreateBriefSessionHandler).Methods("POST")
 	r.HandleFunc("/api/brief-sessions/{id}", handlers.GetBriefSessionHandler).Methods("GET")
 	r.HandleFunc("/api/brief-sessions/{id}/answers", handlers.AnswerBriefSessionHandler).Methods("POST")

--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -157,6 +157,7 @@ Additions:
 
 - `GET /api/personas` / `POST /api/personas` / `PATCH /api/personas/{id}` — persona CRUD.
 - `GET /api/formats` — read-only registry of available formats.
+- `GET /api/brief-sessions/templates?persona_id=X&format_id=Y` — composed fixed-question template for the selected persona and output format.
 - `POST /api/projects` / `GET /api/projects` / `GET /api/projects/{id}` — project management.
 - `GET /api/sessions/{id}/transcript` — chat-style transcript including parent links.
 - `POST /api/sessions/{id}/answers/{answer_id}/edit` — fork-on-edit for past answers.
@@ -209,6 +210,7 @@ Current implementation status as of 2026-05-02:
 - Phase A4 is implemented and merged: follow-up prompts include parent question, parent answer, and active style guide context; rule-based fallback questions use the same quoted parent-answer prefix; the transcript labels the parent answer as the deep-dive rationale ([#20](https://github.com/terisuke/note_maker/issues/20)). Validation is recorded in [Issue 20 deep-dive rationale validation](../validation/issue-20-deep-dive-rationale-2026-05-02.md).
 - Phase A3 is implemented in code: the generated Markdown textarea is editable, preview rendering live-syncs through `marked`, both preview and Markdown tabs can copy content, and `POST /api/drafts/{id}/regenerate-section` rewrites exactly one `## ` subtree while preserving the rest of the draft byte-for-byte ([#19](https://github.com/terisuke/note_maker/issues/19)). Validation is recorded in [Issue 19 section regeneration validation](../validation/issue-19-section-regeneration-2026-05-02.md).
 - Phase B3/B4 are implemented for the in-repo registry surface: all five formats have prompt fragments, embedded guides, and validators; `terisuke` and `cloudia` ship as distinct seed personas. Deterministic scenario validation is recorded in [Issue 23/24 format and persona seed validation](../validation/issue-23-24-format-persona-seed-2026-05-02.md). Live source-derived guide rebuilding for Zenn/Qiita/RSS remains part of source acquisition work in [#22](https://github.com/terisuke/note_maker/issues/22).
+- Phase B5 is implemented: fixed interview questions are composed server-side by `persona_id × output_format_id`, Cloudia technical modes include extra viewpoint/context prompts, the frontend reads `GET /api/brief-sessions/templates`, and `cmd/scenario/media_matrix` produces a six-case cross-media evaluation matrix for note, Cor blog, Zenn, Qiita, and homepage output ([#25](https://github.com/terisuke/note_maker/issues/25)).
 
 Near-term execution order:
 

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -250,6 +250,8 @@ Acceptance:
 - Starting a `terisuke × note_article` session is byte-identical to the current question set.
 - Custom questions added via the existing config UI are appended after the composed list.
 
+Implementation note as of 2026-05-03: #25 is implemented with `brief.ComposeFixedQuestions(persona_id, output_format_id)` and `GET /api/brief-sessions/templates`. The frontend now displays server templates as read-only rows and sends only custom additions on session start. `cmd/scenario/media_matrix` validates all 2 personas x 5 formats templates and creates a six-case cross-media evaluation matrix for follow-on live LLM runs.
+
 ## Phase C — Memory & history
 
 ### C1 — SQLite store (extends Issue [#14](https://github.com/terisuke/note_maker/issues/14))

--- a/docs/validation/media-matrix-integrated-evaluation-2026-05-03.md
+++ b/docs/validation/media-matrix-integrated-evaluation-2026-05-03.md
@@ -1,0 +1,136 @@
+# Media matrix integrated evaluation
+
+Date: 2026-05-03
+
+## Scope
+
+This validation plan covers the integrated cross-media path after the new source selectors and output modes are available. It intentionally starts offline and deterministic, then documents the live source/LLM runs to execute when a local model and network access are explicitly enabled.
+
+The evaluation must vary all of these dimensions:
+
+- Theme: reflective creation, implementation report, company vision, Zenn tutorial, Qiita how-to, homepage copy.
+- Medium: note, Cor.inc company blog, Zenn, Qiita, homepage HTML section.
+- Style: essay, technical report, vision sharing, tutorial, practical how-to, concise product section.
+- Length: 400-700字 homepage copy through 3000字 note essay.
+
+## Offline matrix scenario
+
+Command:
+
+```sh
+SCENARIO_OUTPUT_DIR=tmp/media_matrix go run ./cmd/scenario/media_matrix
+```
+
+Expected output:
+
+```text
+media matrix scenario completed
+offline_only=true
+source_selectors=5
+question_template_ids=9
+composed_templates=10
+cases=6
+matrix=tmp/media_matrix/matrix.json
+cases_markdown=tmp/media_matrix/cases.md
+```
+
+The command does not call public sources or an LLM. It verifies:
+
+- Seeded personas expose these proven selectors:
+  - `note:cor_instrument`
+  - `zenn:cloudia`
+  - `qiita:Cloudia_Cor_Inc`
+  - `rss:https://cor-jp.com/rss.xml`
+  - `github:Cor-Incorporated/corsweb2024/src/content/blog/ja`
+- The baseline Terisuke note interview template still contains the required brief fields.
+- All 10 composed templates across 2 personas x 5 formats are generated, including Cloudia technical questions and homepage CTA questions.
+- Each case can assemble a completed `ArticleBrief` through the domain session flow using its own `persona_id x output_format_id` question template.
+- Each case prompt contains the expected persona, output format, theme, target length, and medium-specific guide fragments.
+
+Artifacts:
+
+- `tmp/media_matrix/matrix.json`: machine-readable planned run matrix.
+- `tmp/media_matrix/cases.md`: human-readable matrix and per-case live LLM command.
+- `tmp/media_matrix/briefs/*.json`: deterministic `ArticleBrief` inputs for draft generation.
+- `tmp/media_matrix/prompts/*.prompt.md`: generated prompts for inspection.
+
+## Matrix cases
+
+The offline scenario currently covers:
+
+| Case | Medium | Style | Primary selectors |
+|---|---|---|---|
+| `terisuke_note_essay` | note | reflective essay | `note:cor_instrument` |
+| `cor_blog_technical_report` | Cor.inc company blog | technical report | `rss:https://cor-jp.com/rss.xml`, `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` |
+| `cor_blog_vision_sharing` | Cor.inc company blog | vision sharing | `rss:https://cor-jp.com/rss.xml`, `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` |
+| `cloudia_zenn_tutorial` | Zenn | tutorial | `zenn:cloudia` |
+| `cloudia_qiita_how_to` | Qiita | practical how-to | `qiita:Cloudia_Cor_Inc` |
+| `cor_homepage_section` | homepage | concise product section | `rss:https://cor-jp.com/rss.xml`, `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` |
+
+## Optional live source phase
+
+Run only when live network validation is intended:
+
+```sh
+RUN_SOURCE_FETCH_SCENARIO=1 \
+SCENARIO_OUTPUT_DIR=tmp/source_fetch_media_matrix \
+SOURCE_FETCH_LIMIT=100 \
+SOURCE_FETCH_NOTE=note:cor_instrument \
+SOURCE_FETCH_ZENN=zenn:cloudia \
+SOURCE_FETCH_QIITA=qiita:Cloudia_Cor_Inc \
+SOURCE_FETCH_RSS=rss:https://cor-jp.com/rss.xml \
+SOURCE_FETCH_GITHUB=github:Cor-Incorporated/corsweb2024/src/content/blog/ja \
+go run ./cmd/scenario/source_fetch
+```
+
+2026-05-03 live result:
+
+| Selector | Articles | Avg content length | Elapsed seconds | Output |
+|---|---:|---:|---:|---|
+| `note:cor_instrument` | 20 | 5,177 chars | 8.91 | `tmp/source_fetch_media_matrix/note.json` |
+| `zenn:cloudia` | 7 | 4,139 chars | 1.06 | `tmp/source_fetch_media_matrix/zenn.json` |
+| `qiita:Cloudia_Cor_Inc` | 12 | 3,274 chars | 0.30 | `tmp/source_fetch_media_matrix/qiita.json` |
+| `rss:https://cor-jp.com/rss.xml` | 10 | 69 chars | 0.10 | `tmp/source_fetch_media_matrix/rss.json` |
+| `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` | 10 | 4,218 chars | 2.61 | `tmp/source_fetch_media_matrix/github.json` |
+
+## Optional live LLM phase
+
+First generate the offline matrix so the brief files exist:
+
+```sh
+SCENARIO_OUTPUT_DIR=tmp/media_matrix go run ./cmd/scenario/media_matrix
+```
+
+Then run draft generation for one case at a time with an available local LLM and style artifacts. Example:
+
+```sh
+RUN_LOCAL_LLM_SCENARIO=1 \
+AUTHOR_PROFILE_PATH=tmp/author_style/profile.json \
+WRITING_GUIDE_PATH=tmp/author_style/guide.json \
+ARTICLE_BRIEF_PATH=tmp/media_matrix/briefs/cloudia_zenn_tutorial.json \
+SCENARIO_OUTPUT_DIR=tmp/media_matrix/live/cloudia_zenn_tutorial \
+go run ./cmd/scenario/draft_generation
+```
+
+Use the `planned_llm_command` entries in `tmp/media_matrix/matrix.json` or `tmp/media_matrix/cases.md` for the remaining cases, adding `AUTHOR_PROFILE_PATH` and `WRITING_GUIDE_PATH` to point at the style artifacts for the phase under test.
+
+## Comparison table
+
+Compare results across phases and cases with this schema:
+
+| Case | Phase | Medium | Style | Target length | Elapsed seconds | Score | Verification passed | Runes | Output |
+|---|---|---|---|---|---:|---:|---|---:|---|
+| `terisuke_note_essay` | offline matrix | note | reflective essay | 3000字前後 |  |  | prompt checks only |  | `tmp/media_matrix/prompts/terisuke_note_essay.prompt.md` |
+| `terisuke_note_essay` | live draft | note | reflective essay | 3000字前後 |  |  |  |  |  |
+| `cor_blog_technical_report` | live draft | company blog | technical report | 2200-2800字 |  |  |  |  |  |
+| `cor_blog_vision_sharing` | live draft | company blog | vision sharing | 1600-2200字 |  |  |  |  |  |
+| `cloudia_zenn_tutorial` | live draft | Zenn | tutorial | 1800-2400字 |  |  |  |  |  |
+| `cloudia_qiita_how_to` | live draft | Qiita | practical how-to | 1400-2000字 |  |  |  |  |  |
+| `cor_homepage_section` | live draft | homepage | concise product section | 400-700字 |  |  |  |  |  |
+
+Acceptance criteria for the integrated evaluation:
+
+- Offline matrix passes before any live work.
+- Live source phase confirms each selector still returns usable material, with GitHub Markdown preferred over RSS for full Cor.inc blog body text.
+- Each live draft records `elapsed_seconds`, style `score`, `passed`, `verification_performed`, `verification_passed`, and `runes` from `cmd/scenario/draft_generation`.
+- Failures are grouped by dimension: source selector, persona, medium/output format, style, target length, or verifier result.

--- a/internal/application/brief/service.go
+++ b/internal/application/brief/service.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	domain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 // FollowUpGenerator can phrase deep-dive questions; services fall back to domain rules on error.
@@ -53,10 +55,16 @@ func NewInterviewService(followUpGenerator FollowUpGenerator) *InterviewService 
 
 // StartSession creates a session and returns the first fixed question.
 func (s *InterviewService) StartSession(input StartSessionInput) (InterviewResult, error) {
-	if len(input.Questions) == 0 {
-		input.Questions = domain.FixedQuestions()
+	personaID := personadomain.NormalizeID(input.PersonaID)
+	formatID := outputformat.NormalizeID(input.OutputFormatID)
+	if strings.TrimSpace(input.OutputFormatID) == "" {
+		if persona, ok := personadomain.DefaultRegistry().Get(personaID); ok {
+			formatID = persona.DefaultFormat
+		}
 	}
-	session, err := domain.NewArticleBriefSessionWithOptions(input.SessionID, input.StyleProfileID, input.PersonaID, input.OutputFormatID, "", input.Questions)
+	questions := domain.ComposeFixedQuestions(personaID, formatID)
+	questions = append(questions, input.Questions...)
+	session, err := domain.NewArticleBriefSessionWithOptions(input.SessionID, input.StyleProfileID, personaID, formatID, "", questions)
 	if err != nil {
 		return InterviewResult{}, err
 	}

--- a/internal/application/brief/service_test.go
+++ b/internal/application/brief/service_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	domain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	"github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 func TestInterviewServiceStartsAndCompletesWorkflow(t *testing.T) {
@@ -151,6 +153,55 @@ func TestInterviewServiceForksEditedAnswerAndReturnsNextQuestion(t *testing.T) {
 	}
 }
 
+func TestInterviewServiceAppendsCustomQuestionsAfterComposedTemplate(t *testing.T) {
+	service := NewInterviewService(nil)
+	result, err := service.StartSession(StartSessionInput{
+		SessionID:      "session-custom",
+		StyleProfileID: "style-1",
+		PersonaID:      persona.IDCloudia,
+		OutputFormatID: outputformat.IDZennArticle,
+		Questions: []domain.ArticleQuestion{
+			{
+				ID:          "custom_reference",
+				Text:        "参考リンクとして必ず確認するURLは何ですか？",
+				FlowType:    domain.QuestionFlowMain,
+				TargetField: "custom",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	template := domain.ComposeFixedQuestions(persona.IDCloudia, outputformat.IDZennArticle)
+	if len(result.Session.Questions) != len(template)+1 {
+		t.Fatalf("question count = %d, want %d", len(result.Session.Questions), len(template)+1)
+	}
+	if result.Session.Questions[len(template)-1].ID != domain.QuestionIDCloudiaViewpoint {
+		t.Fatalf("last template question = %#v", result.Session.Questions[len(template)-1])
+	}
+	if result.Session.Questions[len(result.Session.Questions)-1].ID != "custom_reference" {
+		t.Fatalf("custom question was not appended last: %#v", result.Session.Questions)
+	}
+}
+
+func TestInterviewServiceUsesPersonaDefaultFormatForTemplate(t *testing.T) {
+	service := NewInterviewService(nil)
+	result, err := service.StartSession(StartSessionInput{
+		SessionID:      "session-cloudia-default",
+		StyleProfileID: "style-1",
+		PersonaID:      persona.IDCloudia,
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if result.Session.OutputFormatID != outputformat.IDZennArticle {
+		t.Fatalf("output format = %q, want %q", result.Session.OutputFormatID, outputformat.IDZennArticle)
+	}
+	if !sessionHasQuestion(result.Session.Questions, domain.QuestionIDTargetStack) {
+		t.Fatalf("cloudia default template missing target_stack: %#v", result.Session.Questions)
+	}
+}
+
 func fixedAnswers() []string {
 	return []string{
 		"Local article generation with a small deterministic workflow.",
@@ -163,6 +214,15 @@ func fixedAnswers() []string {
 		"3000字前後 with six sections.",
 		"Practical and introspective.",
 	}
+}
+
+func sessionHasQuestion(questions []domain.ArticleQuestion, id string) bool {
+	for _, question := range questions {
+		if question.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 type staticFollowUpGenerator struct {

--- a/internal/domain/brief/session_test.go
+++ b/internal/domain/brief/session_test.go
@@ -1,8 +1,12 @@
 package brief
 
 import (
+	"reflect"
 	"strings"
 	"testing"
+
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	"github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 func TestFixedQuestionsAreDeterministic(t *testing.T) {
@@ -41,6 +45,48 @@ func TestFixedQuestionsAreDeterministic(t *testing.T) {
 		}
 		if question.FlowType != QuestionFlowMain {
 			t.Fatalf("question %d flow = %q, want %q", i, question.FlowType, QuestionFlowMain)
+		}
+	}
+}
+
+func TestComposeFixedQuestionsCoversPersonasAndFormats(t *testing.T) {
+	personas := []string{persona.IDTerisuke, persona.IDCloudia}
+	formats := []string{
+		outputformat.IDNoteArticle,
+		outputformat.IDMarkdownBlog,
+		outputformat.IDZennArticle,
+		outputformat.IDQiitaArticle,
+		outputformat.IDHomepageSection,
+	}
+	for _, personaID := range personas {
+		for _, formatID := range formats {
+			t.Run(personaID+"_"+formatID, func(t *testing.T) {
+				questions := ComposeFixedQuestions(personaID, formatID)
+				if len(questions) < len(FixedQuestions()) {
+					t.Fatalf("question count = %d, want at least %d", len(questions), len(FixedQuestions()))
+				}
+				assertUniqueQuestionIDs(t, questions)
+				if personaID == persona.IDTerisuke && formatID == outputformat.IDNoteArticle {
+					if !reflect.DeepEqual(questions, FixedQuestions()) {
+						t.Fatalf("terisuke note_article template changed:\ngot  %#v\nwant %#v", questions, FixedQuestions())
+					}
+					return
+				}
+				switch formatID {
+				case outputformat.IDNoteArticle:
+					assertQuestionPresent(t, questions, QuestionIDStoryArc)
+				case outputformat.IDMarkdownBlog, outputformat.IDZennArticle, outputformat.IDQiitaArticle:
+					assertQuestionPresent(t, questions, QuestionIDTargetStack)
+				case outputformat.IDHomepageSection:
+					assertQuestionPresent(t, questions, QuestionIDHomepageCTA)
+				}
+				if personaID == persona.IDCloudia {
+					assertQuestionPresent(t, questions, QuestionIDCloudiaViewpoint)
+				}
+				if personaID == persona.IDCloudia && formatID == outputformat.IDZennArticle {
+					assertQuestionPresent(t, questions, QuestionIDTargetStack)
+				}
+			})
 		}
 	}
 }
@@ -293,4 +339,25 @@ func answeredFixedSession(t *testing.T, overrides map[string]string) ArticleBrie
 		}
 	}
 	return session
+}
+
+func assertQuestionPresent(t *testing.T, questions []ArticleQuestion, id string) {
+	t.Helper()
+	for _, question := range questions {
+		if question.ID == id {
+			return
+		}
+	}
+	t.Fatalf("question %q was not present in %#v", id, questions)
+}
+
+func assertUniqueQuestionIDs(t *testing.T, questions []ArticleQuestion) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, question := range questions {
+		if seen[question.ID] {
+			t.Fatalf("duplicate question id %q in %#v", question.ID, questions)
+		}
+		seen[question.ID] = true
+	}
 }

--- a/internal/domain/brief/types.go
+++ b/internal/domain/brief/types.go
@@ -18,6 +18,12 @@ const (
 	QuestionIDExclusions            = "exclusions"
 	QuestionIDTargetLengthStructure = "target_length_structure"
 	QuestionIDToneStance            = "tone_stance"
+	QuestionIDStoryArc              = "story_arc"
+	QuestionIDTargetStack           = "target_stack"
+	QuestionIDTechnicalProof        = "technical_proof"
+	QuestionIDHomepageCTA           = "homepage_cta"
+	QuestionIDHomepageTrust         = "homepage_trust"
+	QuestionIDCloudiaViewpoint      = "cloudia_viewpoint"
 
 	MaxFollowUpsPerTarget = 2
 	MaxTotalFollowUps     = 4
@@ -220,5 +226,104 @@ func FixedQuestions() []ArticleQuestion {
 			Required:    true,
 			TargetField: "tone_stance",
 		},
+	}
+}
+
+// ComposeFixedQuestions returns the server-side interview template for a persona and output format.
+func ComposeFixedQuestions(personaID, outputFormatID string) []ArticleQuestion {
+	personaID = persona.NormalizeID(personaID)
+	if strings.TrimSpace(outputFormatID) == "" {
+		if item, ok := persona.DefaultRegistry().Get(personaID); ok {
+			outputFormatID = item.DefaultFormat
+		}
+	}
+	outputFormatID = outputformat.NormalizeID(outputFormatID)
+	if personaID == persona.IDTerisuke && outputFormatID == outputformat.IDNoteArticle {
+		return FixedQuestions()
+	}
+
+	questions := FixedQuestions()
+	questions = append(questions, formatExtensionQuestions(outputFormatID)...)
+	questions = append(questions, personaExtensionQuestions(personaID)...)
+	return NormalizeQuestions(questions)
+}
+
+func formatExtensionQuestions(outputFormatID string) []ArticleQuestion {
+	switch outputFormatID {
+	case outputformat.IDNoteArticle:
+		return narrativeExtensionQuestions()
+	case outputformat.IDMarkdownBlog, outputformat.IDZennArticle, outputformat.IDQiitaArticle:
+		return technicalExtensionQuestions()
+	case outputformat.IDHomepageSection:
+		return homepageExtensionQuestions()
+	default:
+		return nil
+	}
+}
+
+func narrativeExtensionQuestions() []ArticleQuestion {
+	return []ArticleQuestion{
+		{
+			ID:          QuestionIDStoryArc,
+			Text:        "読み物として印象に残すため、どんな感情の流れやオチを置きますか？",
+			FlowType:    QuestionFlowMain,
+			Required:    false,
+			TargetField: "custom",
+		},
+	}
+}
+
+func technicalExtensionQuestions() []ArticleQuestion {
+	return []ArticleQuestion{
+		{
+			ID:          QuestionIDTargetStack,
+			Text:        "対象にする技術スタック、言語、ライブラリ、実行環境、前提バージョンは何ですか？",
+			FlowType:    QuestionFlowMain,
+			Required:    true,
+			TargetField: "custom",
+		},
+		{
+			ID:          QuestionIDTechnicalProof,
+			Text:        "記事内で示す再現手順、コード例、検証結果、失敗例は何ですか？",
+			FlowType:    QuestionFlowMain,
+			Required:    false,
+			TargetField: "custom",
+		},
+	}
+}
+
+func homepageExtensionQuestions() []ArticleQuestion {
+	return []ArticleQuestion{
+		{
+			ID:          QuestionIDHomepageCTA,
+			Text:        "このWebセクションを読んだ人に押してほしいCTAや次の行動は何ですか？",
+			FlowType:    QuestionFlowMain,
+			Required:    true,
+			TargetField: "custom",
+		},
+		{
+			ID:          QuestionIDHomepageTrust,
+			Text:        "サービスや会社への信頼につながる実績、根拠、約束として何を入れますか？",
+			FlowType:    QuestionFlowMain,
+			Required:    false,
+			TargetField: "custom",
+		},
+	}
+}
+
+func personaExtensionQuestions(personaID string) []ArticleQuestion {
+	switch personaID {
+	case persona.IDCloudia:
+		return []ArticleQuestion{
+			{
+				ID:          QuestionIDCloudiaViewpoint,
+				Text:        "クラウディアならではの視点や感想として、どんな驚き、楽しさ、つまずきを入れますか？",
+				FlowType:    QuestionFlowMain,
+				Required:    false,
+				TargetField: "custom",
+			},
+		}
+	default:
+		return nil
 	}
 }

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -95,6 +95,12 @@ type briefSessionResponse struct {
 	Answers         []briefdomain.BriefAnswer `json:"answers"`
 }
 
+type briefSessionTemplateResponse struct {
+	PersonaID      string                `json:"persona_id"`
+	OutputFormatID string                `json:"output_format_id"`
+	Questions      []articleQuestionJSON `json:"questions"`
+}
+
 type articleQuestionJSON struct {
 	ID               string `json:"id"`
 	Text             string `json:"text"`
@@ -143,6 +149,29 @@ func ListPersonasHandler(w http.ResponseWriter, r *http.Request) {
 // ListFormatsHandler returns built-in output formats.
 func ListFormatsHandler(w http.ResponseWriter, r *http.Request) {
 	respondWithJSON(w, http.StatusOK, outputformat.DefaultRegistry().List())
+}
+
+// GetBriefSessionTemplateHandler returns the composed fixed-question template.
+func GetBriefSessionTemplateHandler(w http.ResponseWriter, r *http.Request) {
+	persona, ok := personadomain.DefaultRegistry().Get(r.URL.Query().Get("persona_id"))
+	if !ok {
+		respondWithError(w, "UNKNOWN_PERSONA", "Persona was not found", r.URL.Query().Get("persona_id"), http.StatusBadRequest)
+		return
+	}
+	formatID := outputformat.NormalizeID(r.URL.Query().Get("format_id"))
+	if strings.TrimSpace(r.URL.Query().Get("format_id")) == "" {
+		formatID = persona.DefaultFormat
+	}
+	format, ok := outputformat.DefaultRegistry().Get(formatID)
+	if !ok {
+		respondWithError(w, "UNKNOWN_OUTPUT_FORMAT", "Output format was not found", formatID, http.StatusBadRequest)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, briefSessionTemplateResponse{
+		PersonaID:      persona.ID,
+		OutputFormatID: format.ID,
+		Questions:      toArticleQuestionJSONList(briefdomain.ComposeFixedQuestions(persona.ID, format.ID)),
+	})
 }
 
 // SeedAuthorStyleHandler stores a practical persona preset as a style guide.
@@ -831,14 +860,8 @@ func toAuthorStyleResponse(result authorstyleapp.AnalyzeResult) authorStyleRespo
 func toBriefSessionResponse(result briefapp.InterviewResult) briefSessionResponse {
 	var question *articleQuestionJSON
 	if result.NextQuestion != nil {
-		question = &articleQuestionJSON{
-			ID:               result.NextQuestion.ID,
-			Text:             result.NextQuestion.Text,
-			FlowType:         string(result.NextQuestion.FlowType),
-			TargetField:      result.NextQuestion.TargetField,
-			TargetQuestionID: result.NextQuestion.TargetQuestionID,
-			FollowUpIndex:    result.NextQuestion.FollowUpIndex,
-		}
+		value := toArticleQuestionJSON(*result.NextQuestion)
+		question = &value
 	}
 	return briefSessionResponse{
 		SessionID:       result.Session.ID,
@@ -851,6 +874,25 @@ func toBriefSessionResponse(result briefapp.InterviewResult) briefSessionRespons
 		NextQuestion:    question,
 		Brief:           result.Brief,
 		Answers:         result.Session.Answers,
+	}
+}
+
+func toArticleQuestionJSONList(questions []briefdomain.ArticleQuestion) []articleQuestionJSON {
+	result := make([]articleQuestionJSON, 0, len(questions))
+	for _, question := range questions {
+		result = append(result, toArticleQuestionJSON(question))
+	}
+	return result
+}
+
+func toArticleQuestionJSON(question briefdomain.ArticleQuestion) articleQuestionJSON {
+	return articleQuestionJSON{
+		ID:               question.ID,
+		Text:             question.Text,
+		FlowType:         string(question.FlowType),
+		TargetField:      question.TargetField,
+		TargetQuestionID: question.TargetQuestionID,
+		FollowUpIndex:    question.FollowUpIndex,
 	}
 }
 

--- a/internal/handlers/workflow_handler_test.go
+++ b/internal/handlers/workflow_handler_test.go
@@ -103,6 +103,33 @@ func TestCreateBriefSessionHandlerCreatesAndPersistsSession(t *testing.T) {
 	}
 }
 
+func TestCreateBriefSessionHandlerAppendsCustomQuestionsAfterTemplate(t *testing.T) {
+	style := setupWorkflowStyle(t)
+	body := `{"style_profile_id":"` + style.Profile.ID + `","session_id":"session-custom","persona_id":"cloudia","output_format_id":"zenn_article","questions":[{"id":"custom_reference","text":"参考リンクとして必ず確認するURLは何ですか？"}]}`
+	request := httptest.NewRequest(http.MethodPost, "/api/brief-sessions", bytes.NewBufferString(body))
+	response := httptest.NewRecorder()
+
+	CreateBriefSessionHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	session, ok := workflowStore.GetSession("session-custom")
+	if !ok {
+		t.Fatal("created session was not saved")
+	}
+	template := briefdomain.ComposeFixedQuestions(personadomain.IDCloudia, outputformat.IDZennArticle)
+	if len(session.Questions) != len(template)+1 {
+		t.Fatalf("question count = %d, want %d", len(session.Questions), len(template)+1)
+	}
+	if session.Questions[len(template)-1].ID != briefdomain.QuestionIDCloudiaViewpoint {
+		t.Fatalf("last template question = %#v", session.Questions[len(template)-1])
+	}
+	if session.Questions[len(session.Questions)-1].ID != "custom_reference" {
+		t.Fatalf("custom question was not appended after template: %#v", session.Questions)
+	}
+}
+
 func TestCreateBriefSessionHandlerValidatesInputs(t *testing.T) {
 	style := setupWorkflowStyle(t)
 	tests := []struct {

--- a/internal/handlers/workflow_mode_test.go
+++ b/internal/handlers/workflow_mode_test.go
@@ -5,6 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	briefdomain "github.com/teradakousuke/note_maker/internal/domain/brief"
+	outputformat "github.com/teradakousuke/note_maker/internal/domain/format"
+	personadomain "github.com/teradakousuke/note_maker/internal/domain/persona"
 )
 
 func TestListPersonasHandler(t *testing.T) {
@@ -52,4 +56,40 @@ func TestListFormatsHandler(t *testing.T) {
 	if !foundZenn {
 		t.Fatalf("zenn_article format with metadata requirement not found: %#v", payload)
 	}
+}
+
+func TestGetBriefSessionTemplateHandlerReturnsComposedQuestions(t *testing.T) {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/brief-sessions/templates?persona_id=cloudia&format_id=zenn_article", nil)
+
+	GetBriefSessionTemplateHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.Code, response.Body.String())
+	}
+	var payload briefSessionTemplateResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode template: %v", err)
+	}
+	if payload.PersonaID != personadomain.IDCloudia || payload.OutputFormatID != outputformat.IDZennArticle {
+		t.Fatalf("unexpected template identity: %#v", payload)
+	}
+	if len(payload.Questions) != len(briefdomain.ComposeFixedQuestions(personadomain.IDCloudia, outputformat.IDZennArticle)) {
+		t.Fatalf("question count = %d", len(payload.Questions))
+	}
+	if !hasQuestionJSON(payload.Questions, briefdomain.QuestionIDTargetStack) {
+		t.Fatalf("target_stack missing from template: %#v", payload.Questions)
+	}
+	if !hasQuestionJSON(payload.Questions, briefdomain.QuestionIDCloudiaViewpoint) {
+		t.Fatalf("cloudia viewpoint missing from template: %#v", payload.Questions)
+	}
+}
+
+func hasQuestionJSON(questions []articleQuestionJSON, id string) bool {
+	for _, question := range questions {
+		if question.ID == id {
+			return true
+		}
+	}
+	return false
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -169,6 +169,34 @@ body {
     min-width: 0;
 }
 
+.question-config-row.template input {
+    background: #f8fafc;
+    color: var(--muted);
+}
+
+.question-config-tag {
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 6px 10px;
+    color: var(--muted);
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+
+.question-config-status {
+    border: 1px dashed var(--line);
+    border-radius: 6px;
+    padding: 10px 12px;
+    color: var(--muted);
+    background: #fff;
+}
+
+.question-config-status.error {
+    border-color: #fecaca;
+    color: #b91c1c;
+    background: #fef2f2;
+}
+
 label {
     font-weight: 600;
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,16 +1,33 @@
 document.addEventListener('DOMContentLoaded', () => {
   const configStorageKey = 'note-maker-config-v1';
-  const defaultQuestions = [
-    { id: 'theme', text: '記事の中心テーマは何ですか？', flow_type: 'main', target_field: 'theme' },
-    { id: 'opening_episode', text: '記事の導入に置く具体的な体験や場面は何ですか？', flow_type: 'main', target_field: 'opening_episode' },
-    { id: 'reader', text: 'この記事を届けたい読者は誰ですか？', flow_type: 'main', target_field: 'reader' },
-    { id: 'expected_reader_action', text: '読後に読者へどんな変化や行動を起こしてほしいですか？', flow_type: 'main', target_field: 'expected_reader_action' },
-    { id: 'must_include', text: '記事に必ず含める論点、事実、手順は何ですか？', flow_type: 'main', target_field: 'must_include' },
-    { id: 'personal_context', text: '著者本人の経験、肩書き、失敗、価値観など、記事に入れるべき属人的な文脈は何ですか？', flow_type: 'main', target_field: 'personal_context' },
-    { id: 'exclusions', text: '記事に含めないこと、避けたい表現、断言しないことは何ですか？', flow_type: 'main', target_field: 'exclusions' },
-    { id: 'target_length_structure', text: '目標文字数と記事構成を指定してください。例: 3000字前後、導入・背景・実装・検証・提案・結論。', flow_type: 'main', target_field: 'target_length_structure' },
-    { id: 'tone_stance', text: '記事のトーンや立場はどうしますか？内省、技術解説、実用、物語性の比重も指定してください。', flow_type: 'main', target_field: 'tone_stance' },
-  ];
+  const legacyTemplateQuestionIds = new Set([
+    'theme',
+    'opening_episode',
+    'reader',
+    'expected_reader_action',
+    'must_include',
+    'personal_context',
+    'exclusions',
+    'target_length_structure',
+    'tone_stance',
+    'cor_blog_purpose',
+    'cor_blog_category',
+    'cor_blog_metadata',
+    'cor_blog_evidence',
+    'cor_blog_next_action',
+    'target_stack',
+    'prerequisite_knowledge',
+    'code_examples',
+    'references',
+    'target_conversion',
+    'primary_cta',
+    'brand_voice',
+    'story_arc',
+    'technical_proof',
+    'homepage_cta',
+    'homepage_trust',
+    'cloudia_viewpoint',
+  ]);
 
   const config = loadConfig();
   const state = {
@@ -22,6 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
     completedBrief: null,
     personas: [],
     formats: [],
+    templateQuestions: [],
+    templateLoading: false,
+    templateError: '',
+    templateRequestId: 0,
     questionTextById: {},
     lastSubmittedAnswer: '',
     answerAbortController: null,
@@ -127,6 +148,7 @@ document.addEventListener('DOMContentLoaded', () => {
       populateFormatSelect();
       applyPersonaDefaults(false);
       renderModeSummary();
+      loadQuestionTemplate();
     } catch (error) {
       showError(`書き分け設定の取得に失敗しました: ${error.message}`);
     }
@@ -223,7 +245,7 @@ document.addEventListener('DOMContentLoaded', () => {
       state.nextQuestion = data.next_question;
       state.answers = data.answers || [];
       state.completedBrief = null;
-      rememberQuestions(currentQuestions());
+      rememberQuestions([...state.templateQuestions, ...currentQuestions()]);
       rememberQuestion(data.next_question);
       el.interviewArea.classList.remove('hidden');
       el.briefResult.classList.add('hidden');
@@ -676,13 +698,14 @@ document.addEventListener('DOMContentLoaded', () => {
     applyPersonaDefaults(true);
     saveConfig();
     renderModeSummary();
+    loadQuestionTemplate();
   }
 
   function onFormatChange() {
     config.mode.format = currentFormatId();
     saveConfig();
     renderModeSummary();
-    renderQuestionConfig();
+    loadQuestionTemplate();
   }
 
   function applyPersonaDefaults(forceFormat) {
@@ -698,7 +721,6 @@ document.addEventListener('DOMContentLoaded', () => {
       el.formatSelect.value = persona.default_format;
       config.mode.format = persona.default_format;
     }
-    renderQuestionConfig();
   }
 
   function renderModeSummary() {
@@ -739,38 +761,124 @@ document.addEventListener('DOMContentLoaded', () => {
     saveConfig();
   }
 
+  async function loadQuestionTemplate() {
+    const personaId = currentPersonaId();
+    const formatId = currentFormatId();
+    if (!personaId || !formatId) {
+      state.templateQuestions = [];
+      state.templateError = '';
+      state.templateLoading = false;
+      renderQuestionConfig();
+      return;
+    }
+
+    const requestId = state.templateRequestId + 1;
+    state.templateRequestId = requestId;
+    state.templateLoading = true;
+    state.templateError = '';
+    state.templateQuestions = [];
+    renderQuestionConfig();
+
+    try {
+      const params = new URLSearchParams({ persona_id: personaId, format_id: formatId });
+      const data = await requestJSON(`/api/brief-sessions/templates?${params.toString()}`);
+      if (requestId !== state.templateRequestId) {
+        return;
+      }
+      state.templateQuestions = normalizeTemplateQuestions(data);
+      rememberQuestions(state.templateQuestions);
+    } catch (error) {
+      if (requestId !== state.templateRequestId) {
+        return;
+      }
+      state.templateQuestions = [];
+      state.templateError = `テンプレート質問を取得できませんでした: ${error.message}`;
+    } finally {
+      if (requestId === state.templateRequestId) {
+        state.templateLoading = false;
+        renderQuestionConfig();
+      }
+    }
+  }
+
   function renderQuestionConfig() {
     el.questionConfigList.innerHTML = '';
-    config.questions.forEach((question, index) => {
-      const row = document.createElement('div');
-      row.className = 'question-config-row';
 
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = question.text;
-      input.addEventListener('input', () => {
-        config.questions[index].text = input.value;
-        saveConfig();
-      });
+    if (state.templateLoading) {
+      el.questionConfigList.appendChild(createQuestionConfigStatus('テンプレート質問を読み込んでいます...'));
+    }
 
-      const remove = document.createElement('button');
-      remove.type = 'button';
-      remove.className = 'secondary-btn';
-      remove.textContent = '削除';
-      remove.disabled = isFixedQuestion(question.id);
-      remove.addEventListener('click', () => {
-        config.questions.splice(index, 1);
-        saveConfig();
-        renderQuestionConfig();
-      });
-
-      row.append(input, remove);
-      el.questionConfigList.appendChild(row);
+    state.templateQuestions.forEach((question) => {
+      el.questionConfigList.appendChild(createTemplateQuestionRow(question));
     });
+
+    if (state.templateError) {
+      el.questionConfigList.appendChild(createQuestionConfigStatus(state.templateError, true));
+    }
+
+    config.customQuestions.forEach((question, index) => {
+      el.questionConfigList.appendChild(createCustomQuestionRow(question, index));
+    });
+
+    if (!state.templateLoading && !state.templateQuestions.length && !state.templateError && !config.customQuestions.length) {
+      el.questionConfigList.appendChild(createQuestionConfigStatus('テンプレート質問はありません。追加質問を入力できます。'));
+    }
+  }
+
+  function createTemplateQuestionRow(question) {
+    const row = document.createElement('div');
+    row.className = 'question-config-row template';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = question.text;
+    input.readOnly = true;
+    input.setAttribute('aria-label', 'テンプレート質問');
+
+    const label = document.createElement('span');
+    label.className = 'question-config-tag';
+    label.textContent = 'テンプレート';
+
+    row.append(input, label);
+    return row;
+  }
+
+  function createCustomQuestionRow(question, index) {
+    const row = document.createElement('div');
+    row.className = 'question-config-row custom';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = question.text;
+    input.setAttribute('aria-label', '追加質問');
+    input.addEventListener('input', () => {
+      config.customQuestions[index].text = input.value;
+      saveConfig();
+    });
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'secondary-btn';
+    remove.textContent = '削除';
+    remove.addEventListener('click', () => {
+      config.customQuestions.splice(index, 1);
+      saveConfig();
+      renderQuestionConfig();
+    });
+
+    row.append(input, remove);
+    return row;
+  }
+
+  function createQuestionConfigStatus(message, isError = false) {
+    const status = document.createElement('div');
+    status.className = `question-config-status${isError ? ' error' : ''}`;
+    status.textContent = message;
+    return status;
   }
 
   function addQuestion() {
-    config.questions.push({
+    config.customQuestions.push({
       id: `custom_${Date.now()}`,
       text: '追加で聞きたい質問を入力してください',
       flow_type: 'main',
@@ -781,48 +889,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function resetQuestions() {
-    config.questions = cloneQuestions(defaultQuestions);
+    config.customQuestions = [];
     saveConfig();
-    renderQuestionConfig();
+    loadQuestionTemplate();
   }
 
   function currentQuestions() {
-    return [...config.questions, ...formatQuestions(currentFormatId())]
-      .map((question) => ({
-        id: question.id,
-        text: question.text.trim(),
-        flow_type: question.flow_type || 'main',
-        target_field: question.target_field || 'custom',
-      }))
-      .filter((question) => question.id && question.text);
-  }
-
-  function formatQuestions(formatId) {
-    if (formatId === 'markdown_blog') {
-      return [
-        { id: 'cor_blog_purpose', text: '会社ブログとしての主目的は何ですか？例: 技術知見の報告、実装判断の共有、社員へのビジョン共有。', flow_type: 'main', target_field: 'custom' },
-        { id: 'cor_blog_category', text: 'カテゴリは ai / engineering / founder / lab のどれにしますか？理由も教えてください。', flow_type: 'main', target_field: 'custom' },
-        { id: 'cor_blog_metadata', text: 'slug候補、タグ3-5個、featuredの有無、画像パスがあれば指定してください。', flow_type: 'main', target_field: 'custom' },
-        { id: 'cor_blog_evidence', text: '本文に入れる具体的な実装、検証結果、数値、意思決定の根拠は何ですか？', flow_type: 'main', target_field: 'custom' },
-        { id: 'cor_blog_next_action', text: '社員や読者に、この記事を読んだ後どんな判断や行動をしてほしいですか？', flow_type: 'main', target_field: 'custom' },
-      ];
-    }
-    if (formatId === 'zenn_article' || formatId === 'qiita_article') {
-      return [
-        { id: 'target_stack', text: '対象技術スタック、バージョン、実行環境は何ですか？', flow_type: 'main', target_field: 'custom' },
-        { id: 'prerequisite_knowledge', text: '読者に前提として求める知識と、説明を厚くする箇所はどこですか？', flow_type: 'main', target_field: 'custom' },
-        { id: 'code_examples', text: '必ず入れるコード例、コマンド、設定ファイルは何ですか？', flow_type: 'main', target_field: 'custom' },
-        { id: 'references', text: '参照すべき公式ドキュメント、記事、リポジトリURLはありますか？', flow_type: 'main', target_field: 'custom' },
-      ];
-    }
-    if (formatId === 'homepage_section') {
-      return [
-        { id: 'target_conversion', text: 'このHTMLセクションで読者に起こしてほしい行動は何ですか？', flow_type: 'main', target_field: 'custom' },
-        { id: 'primary_cta', text: 'CTAの文言とリンク先は何にしますか？', flow_type: 'main', target_field: 'custom' },
-        { id: 'brand_voice', text: '会社サイトとして守りたい言い回し、避けたい表現はありますか？', flow_type: 'main', target_field: 'custom' },
-      ];
-    }
-    return [];
+    const templateIds = new Set(state.templateQuestions.map((question) => question.id));
+    const templateTexts = new Set(state.templateQuestions.map((question) => question.text.trim()).filter(Boolean));
+    return normalizeQuestionList(config.customQuestions)
+      .filter((question) => question.id && question.text && !templateIds.has(question.id) && !templateTexts.has(question.text));
   }
 
   function currentPersonaId() {
@@ -841,24 +917,31 @@ document.addEventListener('DOMContentLoaded', () => {
     return state.formats.find((format) => format.id === currentFormatId());
   }
 
-  function isFixedQuestion(id) {
-    return defaultQuestions.some((question) => question.id === id);
+  function normalizeTemplateQuestions(data) {
+    const values = Array.isArray(data)
+      ? data
+      : data?.questions || data?.template_questions || data?.template?.questions || data?.Template?.Questions || [];
+    if (!Array.isArray(values)) {
+      return [];
+    }
+    return normalizeQuestionList(values)
+      .map((question) => ({ ...question, template: true }))
+      .filter((question) => question.id && question.text);
   }
 
   function loadConfig() {
     const fallback = {
       mode: { persona: 'terisuke', format: 'note_article' },
       models: { style: 'gemma4:e2b', brief: 'qwen3.6:27b', draft: 'gemma4:31b', verify: 'gemma4:latest' },
-      questions: cloneQuestions(defaultQuestions),
+      customQuestions: [],
     };
     try {
       const saved = JSON.parse(localStorage.getItem(configStorageKey) || '{}');
+      const savedCustomQuestions = saved.customQuestions || saved.custom_questions || migrateLegacyQuestions(saved.questions);
       return {
         models: { ...fallback.models, ...(saved.models || {}) },
         mode: { ...fallback.mode, ...(saved.mode || {}) },
-        questions: Array.isArray(saved.questions) && saved.questions.length
-          ? saved.questions
-          : fallback.questions,
+        customQuestions: normalizeQuestionList(savedCustomQuestions),
       };
     } catch (_) {
       return fallback;
@@ -869,8 +952,32 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem(configStorageKey, JSON.stringify(config));
   }
 
-  function cloneQuestions(questions) {
-    return questions.map((question) => ({ ...question }));
+  function migrateLegacyQuestions(questions) {
+    if (!Array.isArray(questions)) {
+      return [];
+    }
+    return questions.filter((question) => question?.id && !legacyTemplateQuestionIds.has(question.id));
+  }
+
+  function normalizeQuestionList(questions) {
+    if (!Array.isArray(questions)) {
+      return [];
+    }
+    const seen = new Set();
+    return questions
+      .map((question) => ({
+        id: String(question.id || question.ID || '').trim(),
+        text: String(question.text || question.Text || '').trim(),
+        flow_type: question.flow_type || question.FlowType || 'main',
+        target_field: question.target_field || question.TargetField || 'custom',
+      }))
+      .filter((question) => {
+        if (!question.id || !question.text || seen.has(question.id)) {
+          return false;
+        }
+        seen.add(question.id);
+        return true;
+      });
   }
 
   function escapeHTML(value) {


### PR DESCRIPTION
## Summary
- implements server-side `persona_id x output_format_id` interview question composition for #25
- adds `GET /api/brief-sessions/templates` and updates the web UI to fetch read-only server templates while sending only custom questions
- adds an offline media matrix scenario covering note, Cor blog, Zenn, Qiita, and homepage cases with varied theme/style/length
- updates ADR 0002, implementation plan, and validation docs with the integrated evaluation path

## Validation
- `go test ./...`
- `node --check static/js/script.js`
- `git diff --check`
- `go run ./cmd/scenario/media_matrix`
- live source scenario on 2026-05-03:
  - `note:cor_instrument`: 20 articles, avg 5,177 chars
  - `zenn:cloudia`: 7 articles, avg 4,139 chars
  - `qiita:Cloudia_Cor_Inc`: 12 articles, avg 3,274 chars
  - `rss:https://cor-jp.com/rss.xml`: 10 items, avg 69 chars
  - `github:Cor-Incorporated/corsweb2024/src/content/blog/ja`: 10 articles, avg 4,218 chars
- local API smoke on `:18080`:
  - `cloudia x zenn_article` returns `target_stack` + `cloudia_viewpoint`
  - `terisuke x note_article` returns the original 9-question template

## Follow-up
- Full live LLM scoring across the six media-matrix cases should run under #40 because it occupies the Evo X2 primary runtime and belongs with quality/runtime variance tracking.

Closes #25
