### PR TITLE
Align next implementation plan for media-matrix evaluation

### DIFF
--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -195,9 +195,9 @@ The full work is broken into four phases tracked by issues. Each phase is indepe
   - Handler test coverage, Issue [#11](https://github.com/terisuke/note_maker/issues/11) (style threshold), Issue [#13](https://github.com/terisuke/note_maker/issues/13) (Playwright), Issue [#15](https://github.com/terisuke/note_maker/issues/15) (desktop packaging) follow-up.
   - Issue: [#29](https://github.com/terisuke/note_maker/issues/29).
 
-Recommended order: A → C → B → D. Phase C is sequenced before the remaining B work because the persona registry needs durable storage to be useful; running the full persona library on the JSON store would force a second migration.
+Original recommended order was A → C → B → D. Implementation intentionally pulled the minimum B work forward because source acquisition, format validation, persona seeds, and question templates were required before a realistic cross-media evaluation could be defined. With Phases A and B now implemented, the next order is C1 + D1 in parallel, then C2/C3, then the full Evo X2 media-matrix evaluation under #40.
 
-Current implementation status as of 2026-05-02:
+Current implementation status as of 2026-05-03:
 
 - ADR 0001's strict Terisuke style threshold work is complete ([#11](https://github.com/terisuke/note_maker/issues/11)).
 - Phase B1 is complete ahead of the original order: `Persona` and `OutputFormat` concepts, prompt dispatch, and format validators are in place ([#21](https://github.com/terisuke/note_maker/issues/21)). The remaining Phase B work stays deferred until after Phase A/C foundations.
@@ -209,13 +209,14 @@ Current implementation status as of 2026-05-02:
 - Phase A1 is implemented and merged: the interview surface now renders a chat-style transcript, answer bubbles can be edited inline, and edits create child sessions via fork-on-edit while retaining `parent_session_id` lineage ([#17](https://github.com/terisuke/note_maker/issues/17)).
 - Phase A4 is implemented and merged: follow-up prompts include parent question, parent answer, and active style guide context; rule-based fallback questions use the same quoted parent-answer prefix; the transcript labels the parent answer as the deep-dive rationale ([#20](https://github.com/terisuke/note_maker/issues/20)). Validation is recorded in [Issue 20 deep-dive rationale validation](../validation/issue-20-deep-dive-rationale-2026-05-02.md).
 - Phase A3 is implemented in code: the generated Markdown textarea is editable, preview rendering live-syncs through `marked`, both preview and Markdown tabs can copy content, and `POST /api/drafts/{id}/regenerate-section` rewrites exactly one `## ` subtree while preserving the rest of the draft byte-for-byte ([#19](https://github.com/terisuke/note_maker/issues/19)). Validation is recorded in [Issue 19 section regeneration validation](../validation/issue-19-section-regeneration-2026-05-02.md).
-- Phase B3/B4 are implemented for the in-repo registry surface: all five formats have prompt fragments, embedded guides, and validators; `terisuke` and `cloudia` ship as distinct seed personas. Deterministic scenario validation is recorded in [Issue 23/24 format and persona seed validation](../validation/issue-23-24-format-persona-seed-2026-05-02.md). Live source-derived guide rebuilding for Zenn/Qiita/RSS remains part of source acquisition work in [#22](https://github.com/terisuke/note_maker/issues/22).
+- Phase B2/B3/B4 are implemented: historical source acquisition works for note, Zenn, Qiita, Cor RSS, and Cor GitHub Markdown; all five formats have prompt fragments, embedded guides, and validators; `terisuke` and `cloudia` ship as distinct seed personas. Validation is recorded in [Issue 22 source fetcher validation](../validation/issue-22-source-fetchers-2026-05-02.md) and [Issue 23/24 format and persona seed validation](../validation/issue-23-24-format-persona-seed-2026-05-02.md).
 - Phase B5 is implemented: fixed interview questions are composed server-side by `persona_id × output_format_id`, Cloudia technical modes include extra viewpoint/context prompts, the frontend reads `GET /api/brief-sessions/templates`, and `cmd/scenario/media_matrix` produces a six-case cross-media evaluation matrix for note, Cor blog, Zenn, Qiita, and homepage output ([#25](https://github.com/terisuke/note_maker/issues/25)).
 
 Near-term execution order:
 
-1. Merge [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft and per-section regenerate on top of the streamed draft surface.
-2. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks and draft versions survive restarts and section-regeneration candidates can become versioned draft records.
+1. Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) — SQLite history, so answer forks, source-derived guides, media-matrix briefs, draft versions, and evaluation records survive restarts.
+2. Phase D1 ([#29](https://github.com/terisuke/note_maker/issues/29)) in parallel with C1 — raise `workflow.go` handler coverage before more endpoint-heavy UI work lands.
+3. Runtime stabilization ([#40](https://github.com/terisuke/note_maker/issues/40), with runner implementation in [#57](https://github.com/terisuke/note_maker/issues/57)) — use `cmd/scenario/media_matrix` to run varied Note/Qiita/Zenn/Cor blog Evo X2 cases and record endpoint/model/elapsed/score/runes/verification. Full multi-case runs should happen after C1 unless the user explicitly wants one-off artifact files.
 
 ## Tracked issues
 
@@ -234,6 +235,7 @@ Filed 2026-05-02 as part of the PR that introduced this ADR.
 - C2 — [#27](https://github.com/terisuke/note_maker/issues/27) Persona / past-session picker UI
 - C3 — [#28](https://github.com/terisuke/note_maker/issues/28) Render brief and style guide as human-readable cards
 - D1 — [#29](https://github.com/terisuke/note_maker/issues/29) HTTP handler tests for `internal/handlers/workflow.go` (currently 0% coverage)
+- Runtime runner — [#57](https://github.com/terisuke/note_maker/issues/57) Add live LLM media-matrix runner and aggregate evaluator, feeding [#40](https://github.com/terisuke/note_maker/issues/40)
 
 ## Consequences
 

--- a/docs/implementation-plans/issue-adr-guardrails.md
+++ b/docs/implementation-plans/issue-adr-guardrails.md
@@ -1,6 +1,6 @@
 # Issue and ADR guardrails
 
-Date: 2026-05-01 (last updated 2026-05-02)
+Date: 2026-05-01 (last updated 2026-05-03)
 
 This document maps GitHub issues to [ADR 0001](../adrs/0001-three-phase-local-article-generation.md) and [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) and defines implementation guardrails.
 
@@ -21,7 +21,8 @@ Open issues that ADR 0002 reframes (see [ADR 0002 — Tracked issues](../adrs/00
 | [#14](https://github.com/terisuke/note_maker/issues/14) | Persistent queryable database | ADR 0002 §Persistence direction | SQLite migration is the acceptance for #14; multi-persona schema is mandatory. |
 | [#15](https://github.com/terisuke/note_maker/issues/15) | Desktop launcher packaging | Out of ADR 0002 scope | Tracked separately; depends on Phase C completion before packaging makes sense. |
 | [#36](https://github.com/terisuke/note_maker/issues/36) | local llama.cpp fallback quality | ADR 0001/0002 runtime validation | Non-blocking for Phase A. Do not promote fallback as production-quality until it passes strict draft thresholds. |
-| [#40](https://github.com/terisuke/note_maker/issues/40) | Tailnet Evo X2 primary quality and runtime metrics | ADR 0001/0002 runtime validation | Primary runtime must record endpoint/model/elapsed/score/runes and distinguish generation variance from transport failures. |
+| [#40](https://github.com/terisuke/note_maker/issues/40) | Tailnet Evo X2 primary quality and runtime metrics | ADR 0001/0002 runtime validation | Primary runtime must record endpoint/model/elapsed/score/runes and distinguish generation variance from transport failures. It now owns live runs from `cmd/scenario/media_matrix` across note, Qiita, Zenn, and Cor blog. |
+| [#57](https://github.com/terisuke/note_maker/issues/57) | Live media-matrix runner and aggregate evaluator | ADR 0001/0002 runtime validation | Child of #40. Offline mode remains default; live mode must require explicit env vars and must refuse accidental workstation-local fallback for primary Evo X2 validation. |
 
 Closed historical issues:
 
@@ -33,6 +34,10 @@ Closed historical issues:
 | [#6](https://github.com/terisuke/note_maker/issues/6) | API contract alignment | Existing compatibility endpoint remains while new workflow is added. |
 | [#11](https://github.com/terisuke/note_maker/issues/11) | Strict style threshold tuning | Threshold logic is in place; future persona-specific revisions must be tracked separately. |
 | [#21](https://github.com/terisuke/note_maker/issues/21) | Persona and OutputFormat domain concepts | B1 landed early; remaining B work must not expand persistence assumptions until Phase C. |
+| [#22](https://github.com/terisuke/note_maker/issues/22) | Historical source acquisition | Zenn/Qiita/Cor blog sources are available; Cor blog style analysis should prefer GitHub Markdown over RSS summaries. |
+| [#23](https://github.com/terisuke/note_maker/issues/23) | Format prompt templates and validators | Format guides and validators exist; new formats must add validator + guide + scenario sample. |
+| [#24](https://github.com/terisuke/note_maker/issues/24) | Seed `terisuke` and `cloudia` personas | Persona seeds are available; third-persona work must wait for SQLite persistence. |
+| [#25](https://github.com/terisuke/note_maker/issues/25) | Persona/format question templates | Server templates exist; frontend must not duplicate template questions when sending custom questions. |
 
 ## ADR 0002 Phase Map
 
@@ -40,9 +45,9 @@ The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (
 
 - Phase A (Conversation UX): keep domain changes narrow to auditable conversation state transitions such as fork-on-edit. Must keep all existing `go test ./...` green without weakening expectations.
 - Phase A execution started with [#18](https://github.com/terisuke/note_maker/issues/18) because Tailnet Evo X2 runs are long enough that spinner-only UX is no longer acceptable. [#17](https://github.com/terisuke/note_maker/issues/17) follows and reuses the streaming primitives.
-- Phase B (Persona / OutputFormat): introduces `internal/domain/persona` and `internal/domain/format`. The note.com host check moves out of application services into `internal/infrastructure/source/note` only.
+- Phase B (Persona / OutputFormat): implemented for built-in personas, five formats, source acquisition, and question templates. Further persona/library expansion should wait for Phase C persistence.
 - Phase C (SQLite store): repository interfaces stay; only implementations change. JSON-file store becomes import/export utility.
-- Phase D (Quality): handler tests are mandatory before any further endpoint additions land. Coverage gate: `internal/handlers/workflow.go` ≥ 80 %.
+- Phase D (Quality): handler tests are mandatory before any further endpoint-heavy UI work lands. Coverage gate: `internal/handlers/workflow.go` ≥ 80 %.
 
 ## Architectural Guardrails
 
@@ -63,7 +68,7 @@ The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (
    - SSH tunnels are allowed only as explicit developer diagnostics, not as the product default, because they depend on per-device SSH setup.
    - Local llama.cpp (`http://127.0.0.1:8081/v1`) is fallback only. Do not set `LLM_BASE_URL` to local Ollama or local llama.cpp for Evo X2 validation unless the test is explicitly measuring fallback behavior.
    - Runtime validation must report base URL, model, elapsed time, score, and draft length.
-   - Each implementation PR that touches interview, prompt, draft, or runtime behavior should add one scenario datapoint with a deliberately varied medium/persona/format. Do not force every PR to rerun every scenario; build averages by collecting one different slice per phase.
+   - Each implementation PR that touches interview, prompt, draft, or runtime behavior should add one scenario datapoint with a deliberately varied medium/persona/format. Do not force every PR to rerun every scenario; build averages by collecting one different slice per phase. Use `cmd/scenario/media_matrix` as the canonical matrix for final Note/Qiita/Zenn/Cor blog comparison.
    - Draft generation must run the lightweight final verification step before returning the final result; if verification reports NEEDS_REVIEW, surface the report instead of hiding it.
    - If fallback validation fails the strict draft thresholds, keep Evo X2 primary enabled and track fallback hardening separately (Issue [#36](https://github.com/terisuke/note_maker/issues/36)).
    - If Tailnet Evo X2 reaches the API but misses quality gates, track it under Issue [#40](https://github.com/terisuke/note_maker/issues/40), not as a transport regression.
@@ -140,6 +145,13 @@ Scenario tests and commands may require:
 - `RUN_LOCAL_LLM_SCENARIO=1`
 - `LLAMACPP_BASE_URL`
 - `LLAMACPP_MODEL=gemma4:31b`
+
+Current live-media evaluation flow:
+
+1. `go run ./cmd/scenario/media_matrix` creates the deterministic cross-media brief/prompt matrix.
+2. `RUN_SOURCE_FETCH_SCENARIO=1 ... go run ./cmd/scenario/source_fetch` validates current live sources.
+3. #57 implements the resumable live runner and aggregate report.
+4. #40 owns the Evo X2 Tailnet live draft results that fill in elapsed seconds, score, verification, and rune counts for each media-matrix case.
 
 ## Completion Criteria
 

--- a/docs/implementation-plans/multi-persona-multi-format.md
+++ b/docs/implementation-plans/multi-persona-multi-format.md
@@ -26,14 +26,16 @@ The four phases below match ADR 0002. Each is independently shippable.
 | C | Memory: SQLite + history UI | Persistence rewrite, extends [#14](https://github.com/terisuke/note_maker/issues/14) | [#26](https://github.com/terisuke/note_maker/issues/26), [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28) |
 | D | Quality & coverage | Tests + thresholds | [#29](https://github.com/terisuke/note_maker/issues/29) (rolls up [#11](https://github.com/terisuke/note_maker/issues/11), [#13](https://github.com/terisuke/note_maker/issues/13)) |
 
-Recommended order: **A → C → B → D**. Phase B benefits from durable storage (Phase C) being in place first, otherwise the JSON store becomes a temporary obstacle for the persona registry.
+Original recommended order was **A → C → B → D**. The minimum Phase B work was pulled forward because realistic media-specific evaluation needed source fetchers, format validators, persona seeds, and server-side question templates. After the 2026-05-03 merges, the practical order is **C1 + D1 in parallel → C2/C3 → media-matrix Evo X2 evaluation under #40**.
 
-Current status after the 2026-05-02 merges:
+Current status after the 2026-05-03 merges:
 
 - [#11](https://github.com/terisuke/note_maker/issues/11) strict Terisuke style tuning is closed.
 - [#21](https://github.com/terisuke/note_maker/issues/21) B1 landed early: persona/format domain concepts, prompt dispatch, selectors, and validators exist.
 - [#23](https://github.com/terisuke/note_maker/issues/23) is implemented for the in-repo generation surface: every registered format has a prompt fragment, embedded guide, validator, unit coverage, and deterministic sample validation.
 - [#24](https://github.com/terisuke/note_maker/issues/24) is implemented for built-in seeds: `terisuke` and `cloudia` have distinct source bundles, default formats, prompt hints, and unit/scenario coverage. Live source-derived guide rebuilding remains dependent on [#22](https://github.com/terisuke/note_maker/issues/22).
+- [#22](https://github.com/terisuke/note_maker/issues/22) is implemented and revalidated for historical user/article sources. Cor blog style analysis should use GitHub Markdown for full bodies and RSS for discovery.
+- [#25](https://github.com/terisuke/note_maker/issues/25) is implemented: the server composes persona/format question templates, the UI fetches templates, and `cmd/scenario/media_matrix` defines varied cases for note, Cor blog, Zenn, Qiita, and homepage.
 - [#38](https://github.com/terisuke/note_maker/issues/38) Tailnet OpenAI-compatible API is now the Evo X2 primary path. SSH tunnel access is diagnostic-only.
 - [#36](https://github.com/terisuke/note_maker/issues/36) remains open for local llama.cpp fallback quality; it does not block Phase A work.
 - [#40](https://github.com/terisuke/note_maker/issues/40) tracks primary Tailnet Evo X2 quality and runtime-metric stabilization.
@@ -47,7 +49,9 @@ Near-term implementation cut:
 | 2 | [#17](https://github.com/terisuke/note_maker/issues/17) | The transcript can then use the streaming primitives instead of another spinner path. | Implemented and merged: answers render as editable bubbles and edits fork the in-memory session. |
 | 3 | [#20](https://github.com/terisuke/note_maker/issues/20) | Deep-dive rationale belongs in the transcript once the transcript exists. | Implemented in code: every follow-up references the parent answer in prompt and UI, with validation recorded under `docs/validation/`. |
 | 4 | [#19](https://github.com/terisuke/note_maker/issues/19) | Section regeneration is useful only after draft output can stream and be cancelled. | Markdown is editable, preview syncs, and section regeneration replaces only one subtree. |
-| 5 | [#26](https://github.com/terisuke/note_maker/issues/26) | Forked answers and draft versions need durable storage before broader persona library work. | SQLite stores sessions, answers, guides, articles, and draft versions. |
+| 5A | [#26](https://github.com/terisuke/note_maker/issues/26) | Forked answers, media-matrix briefs, draft versions, and evaluation results need durable storage before expensive Evo X2 runs become product memory. | SQLite stores sessions, answers, guides, articles, drafts, and import/export from the JSON store. |
+| 5B | [#29](https://github.com/terisuke/note_maker/issues/29) | #17-#25 added real handler surface; coverage should catch regressions before C2/C3 add more UI and endpoints. | `workflow.go` coverage reaches the agreed gate without real LLM/network. |
+| 6 | [#57](https://github.com/terisuke/note_maker/issues/57) feeding [#40](https://github.com/terisuke/note_maker/issues/40) | The final target is multi-media Evo X2 output evaluation, but repeated live runs should use the persisted context and media matrix. | Note/Qiita/Zenn/Cor blog runs record endpoint/model/elapsed/score/runes/verification in a comparable aggregate report. |
 
 ## Phase A — Conversation UX
 
@@ -325,4 +329,4 @@ Draft generation now includes a lightweight final verification pass before retur
 
 ## Immediate next implementation step
 
-Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#29](https://github.com/terisuke/note_maker/issues/29) are filed. [#18](https://github.com/terisuke/note_maker/issues/18), [#17](https://github.com/terisuke/note_maker/issues/17), and [#20](https://github.com/terisuke/note_maker/issues/20) are merged. [#19](https://github.com/terisuke/note_maker/issues/19) is implemented in code. [#23](https://github.com/terisuke/note_maker/issues/23) and [#24](https://github.com/terisuke/note_maker/issues/24) are implemented for the registry/prompt/validator/seed scope and validated in [Issue 23/24 format and persona seed validation](../validation/issue-23-24-format-persona-seed-2026-05-02.md). Continue with Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) so editable draft state and regeneration history survive restarts; source acquisition remains under [#22](https://github.com/terisuke/note_maker/issues/22).
+Issues [#17](https://github.com/terisuke/note_maker/issues/17)–[#25](https://github.com/terisuke/note_maker/issues/25) are implemented and merged. Continue with Phase C1 ([#26](https://github.com/terisuke/note_maker/issues/26), extending [#14](https://github.com/terisuke/note_maker/issues/14)) and D1 ([#29](https://github.com/terisuke/note_maker/issues/29)) in parallel. Use [#57](https://github.com/terisuke/note_maker/issues/57) and [#40](https://github.com/terisuke/note_maker/issues/40) for the final Evo X2 media-matrix evaluation once persistence can retain expensive run outputs.

--- a/docs/implementation-plans/next-implementation-cut.md
+++ b/docs/implementation-plans/next-implementation-cut.md
@@ -1,63 +1,89 @@
 # Next implementation cut
 
-Date: 2026-05-02
+Date: 2026-05-03
 
-This document translates the current open issue set into the next executable implementation sequence after the Tailnet Evo X2 runtime fixes.
+This document translates the current open issue set into the next executable implementation sequence. The end state is unchanged: run Evo X2 Tailnet scenarios for note, Qiita, Zenn, and Cor.inc company blog with different themes, tones, and target lengths, then compare runtime, score, verification, and final output quality.
 
-## Current issue state
+## Current state
 
-Closed and incorporated:
+Implemented and merged:
 
 - [#11](https://github.com/terisuke/note_maker/issues/11) — strict Terisuke style tuning.
-- [#18](https://github.com/terisuke/note_maker/issues/18) — SSE streaming and cancellation.
 - [#17](https://github.com/terisuke/note_maker/issues/17) — chat transcript and editable answers.
-- [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale in transcript.
+- [#18](https://github.com/terisuke/note_maker/issues/18) — SSE streaming, heartbeat, and cancellation.
+- [#19](https://github.com/terisuke/note_maker/issues/19) — editable draft Markdown and per-section regeneration.
+- [#20](https://github.com/terisuke/note_maker/issues/20) — deep-dive rationale in transcript and prompt.
 - [#21](https://github.com/terisuke/note_maker/issues/21) — Persona and OutputFormat domain concepts.
-- [#38](https://github.com/terisuke/note_maker/issues/38) — Evo X2 Tailnet OpenAI-compatible API as primary runtime.
+- [#22](https://github.com/terisuke/note_maker/issues/22) — historical source acquisition for note, Zenn, Qiita, RSS, HTML, and GitHub Markdown.
+- [#23](https://github.com/terisuke/note_maker/issues/23) — format-specific prompt templates and validators.
+- [#24](https://github.com/terisuke/note_maker/issues/24) — built-in `terisuke` and `cloudia` persona seeds.
+- [#25](https://github.com/terisuke/note_maker/issues/25) — persona- and format-aware question templates plus the media matrix scenario.
+- [#38](https://github.com/terisuke/note_maker/issues/38) — Evo X2 Tailnet OpenAI-compatible API as the primary runtime.
 
 Open and active:
 
-- Phase A: [#19](https://github.com/terisuke/note_maker/issues/19).
-- Phase B remaining: [#22](https://github.com/terisuke/note_maker/issues/22), [#23](https://github.com/terisuke/note_maker/issues/23), [#24](https://github.com/terisuke/note_maker/issues/24), [#25](https://github.com/terisuke/note_maker/issues/25).
-- Phase C: [#26](https://github.com/terisuke/note_maker/issues/26), [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28), extending [#14](https://github.com/terisuke/note_maker/issues/14).
-- Quality and packaging: [#13](https://github.com/terisuke/note_maker/issues/13), [#15](https://github.com/terisuke/note_maker/issues/15), [#29](https://github.com/terisuke/note_maker/issues/29), [#36](https://github.com/terisuke/note_maker/issues/36).
-- Runtime stabilization: [#40](https://github.com/terisuke/note_maker/issues/40) for primary Tailnet Evo X2 quality/metrics.
+- Memory/history: [#26](https://github.com/terisuke/note_maker/issues/26), [#14](https://github.com/terisuke/note_maker/issues/14).
+- History UI and readable artifacts: [#27](https://github.com/terisuke/note_maker/issues/27), [#28](https://github.com/terisuke/note_maker/issues/28).
+- Quality and coverage: [#29](https://github.com/terisuke/note_maker/issues/29), [#13](https://github.com/terisuke/note_maker/issues/13).
+- Runtime evaluation: [#40](https://github.com/terisuke/note_maker/issues/40).
+- Live media-matrix runner: [#57](https://github.com/terisuke/note_maker/issues/57), child of [#40](https://github.com/terisuke/note_maker/issues/40).
+- Fallback and packaging follow-up: [#36](https://github.com/terisuke/note_maker/issues/36), [#45](https://github.com/terisuke/note_maker/issues/45), [#15](https://github.com/terisuke/note_maker/issues/15).
 
-## Next target
+## Final evaluation target
 
-The ordering correction is now applied: [#18](https://github.com/terisuke/note_maker/issues/18), [#17](https://github.com/terisuke/note_maker/issues/17), and [#20](https://github.com/terisuke/note_maker/issues/20) have landed. [#19](https://github.com/terisuke/note_maker/issues/19) is the final Phase A UX cut before Phase C persistence.
+The final integrated evaluation should use `cmd/scenario/media_matrix` as the input matrix, then run live Evo X2 Tailnet draft scenarios for:
 
-Reason: a real Tailnet Evo X2 scenario reached the correct endpoint but took `1396.80s` and still missed quality gates. A spinner-only UI is not usable at that latency. Streaming, heartbeat, cancellation, and partial-result retention are the highest-leverage improvement before reshaping the transcript.
+| Case | Medium | Style | Primary source |
+|---|---|---|---|
+| `terisuke_note_essay` | note | reflective essay | `note:cor_instrument` |
+| `cor_blog_technical_report` | Cor.inc blog | technical report | `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` |
+| `cor_blog_vision_sharing` | Cor.inc blog | vision sharing | `github:Cor-Incorporated/corsweb2024/src/content/blog/ja` |
+| `cloudia_zenn_tutorial` | Zenn | tutorial | `zenn:cloudia` |
+| `cloudia_qiita_how_to` | Qiita | practical how-to | `qiita:Cloudia_Cor_Inc` |
 
-## Implementation sequence
+The homepage section case remains in the matrix as a useful format check, but the user-facing publishing targets for the full Evo X2 run are note, Qiita, Zenn, and the company blog.
 
-1. **[#18] SSE streaming and cancellation**
-   - Add streaming to `internal/infrastructure/llamacpp`.
-   - Add status, heartbeat, token, done, and error event types.
-   - Support cancellation from browser disconnect and explicit Cancel.
-   - Keep non-streaming generation for tests and compatibility.
-   - Status: implemented and merged.
+Each live run must record:
 
-2. **[#17] Chat transcript and editable answers**
-   - Replace the bounded log with a transcript surface.
-   - Render existing fixed and deep-dive answers as bubbles.
-   - Add in-memory fork-on-edit endpoint first; persistence follows in Phase C.
-   - Status: implemented and merged.
+- endpoint and whether it was primary or fallback,
+- model per phase,
+- elapsed seconds,
+- generated runes,
+- style score and failed metrics,
+- final verification result,
+- output path and scenario case id.
 
-3. **[#20] Deep-dive rationale in transcript**
-   - Add parent-answer excerpts to prompt and UI.
-   - Ensure LLM and rule-based fallback paths produce the same contextual prefix.
-   - Status: implemented and merged.
+## Before the full Evo X2 media run
 
-4. **[#19] Editable draft and section regenerate**
-   - Make the Markdown draft editable after streaming lands.
-   - Add section anchor parsing and replacement tests.
-   - Regenerate one heading subtree at a time.
-   - Status: implemented in code; merge before moving to #26.
+There are three prerequisites before running the full multi-medium Evo X2 evaluation:
 
-5. **[#26] SQLite persistence**
-   - Persist answer forks, draft versions, guide versions, and project/article history.
+1. **Persistence first**: #26 must land so media-matrix drafts, evaluations, regenerated sections, answer forks, and style guides can be saved and reopened. Repeated Evo X2 runs are too expensive to leave only as loose files.
+2. **Handler coverage gate**: #29 should run in parallel with #26 and must close before more endpoint-heavy UI work. #17-#25 added real handler surface; the next phase should harden it instead of adding more unguarded routes.
+3. **Scenario ownership**: #40 owns the live Evo X2 media-matrix quality target. [#57](https://github.com/terisuke/note_maker/issues/57) owns the reusable runner/aggregate evaluator that executes the matrix and writes comparable reports.
 
-## Additional gap
+## Parallel implementation plan
 
-[#40](https://github.com/terisuke/note_maker/issues/40) tracks primary-runtime quality and runtime metrics. That work is separate from [#36](https://github.com/terisuke/note_maker/issues/36), which is only for local llama.cpp fallback quality. Do not block [#18](https://github.com/terisuke/note_maker/issues/18) on #40; streaming is needed precisely because these long primary-runtime runs can fail late and still need to preserve partial output.
+Use subagents with disjoint write scopes:
+
+| Lane | Issue | Subagent role | Write scope | Done when |
+|---|---|---|---|---|
+| A | [#26](https://github.com/terisuke/note_maker/issues/26) / [#14](https://github.com/terisuke/note_maker/issues/14) | SQLite worker | `internal/infrastructure/repository/sqlite`, repository interfaces, boot wiring, migrations | JSON store imports, sessions/guides/briefs/drafts persist, cross-persona tests pass |
+| B | [#29](https://github.com/terisuke/note_maker/issues/29) | Handler coverage worker | `internal/handlers/*_test.go`, coverage script/docs | `workflow.go` reaches the agreed coverage gate without real LLM/network |
+| C | [#57](https://github.com/terisuke/note_maker/issues/57), feeding [#40](https://github.com/terisuke/note_maker/issues/40) | Scenario metrics worker | `cmd/scenario/*`, `docs/validation/*`, Make targets | media-matrix live runner records endpoint/model/elapsed/score/runes/verification in aggregate JSON/Markdown |
+
+Lane A and Lane B can run immediately in parallel. Lane C can start by implementing offline/resumable runner mechanics now, but the full multi-case Evo X2 run should wait until Lane A provides persistence or until the user explicitly wants a one-off artifact-file run.
+
+## Recommended order
+
+1. Merge this docs alignment PR.
+2. Start #26 and #29 in parallel.
+3. Merge #29 as soon as handler coverage is sufficient.
+4. Merge #26 once JSON import, SQLite schema, and restart recovery are proven.
+5. Use #57/#40 to run one media-matrix case per implementation phase, then run the full note/Qiita/Zenn/company-blog pass after the persistence layer is stable.
+6. Start #27 and #28 after #26; both depend on persistent projects/sessions/guides.
+7. Start #13 after #27/#28 have enough browser surface to justify E2E tests.
+8. Keep #36/#45 as fallback/runtime P2 work and #15 as packaging after persistence/history are usable.
+
+## Why not run the full Evo X2 matrix now?
+
+The source and prompt matrix is ready, but full Evo X2 draft generation is expensive and can take 20+ minutes per run. Running all media cases before persistence would produce useful files but not durable product memory. The better sequence is to make the system capable of storing those expensive results, then use #40 to evaluate one varied slice per phase and finally run the full comparison table.


### PR DESCRIPTION
## Summary

- Aligns ADR-0002 and implementation docs with the current post-#25 state.
- Sets the next execution order: #26 SQLite persistence and #29 handler coverage in parallel, followed by #27/#28 UI-memory work and #57/#40 Evo X2 media-matrix validation.
- Updates issue guardrails so note, Qiita, Zenn, and company-blog scenario tests remain the final evaluation target.

## Issue / ADR updates

- Created #57 for the live LLM media-matrix runner and aggregate evaluator.
- Updated #40 to consume the media-matrix scope from #56/#25.
- Added planning comments to #26, #29, #13, #36, #27, #28, and #14.
- Tracks this docs alignment with #58.

## Validation

- `git diff --check`

Closes #58
