### PR TITLE
Expose workflow storage mode in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ mise run evo-x2
 
 文体分析結果、取材セッションの回答、完成ブリーフは `WORKFLOW_STORE_PATH` にJSONとして永続化されます。既定値は `data/workflow_store.json` です。
 
-SQLiteを試す場合は `WORKFLOW_STORE_DRIVER=sqlite` を指定します。既定パスは `data/workflow_store.db` で、`WORKFLOW_STORE_PATH` で変更できます。JSON store は互換性のため既定のまま残しています。
+保存方式は設定画面の「保存方式」から選べます。UIで変更した内容は `data/app_config.json` に保存され、サーバー再起動後に反映されます。SQLiteを選んだ場合の既定パスは `data/workflow_store.db` です。JSON store は互換性のため既定のまま残しています。
+
+開発・検証で強制したい場合は `WORKFLOW_STORE_DRIVER=sqlite` を指定できます。この環境変数がある場合、設定画面では保存方式がロック表示になります。
 
 フェーズ別モデルの目安:
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,8 @@ func main() {
 	// APIエンドポイントの設定
 	r.HandleFunc("/api/generate", handlers.GenerateArticleHandler).Methods("POST")
 	r.HandleFunc("/api/models", handlers.ListModelsHandler).Methods("GET")
+	r.HandleFunc("/api/config/storage", handlers.GetStorageConfigHandler).Methods("GET")
+	r.HandleFunc("/api/config/storage", handlers.UpdateStorageConfigHandler).Methods("PATCH")
 	r.HandleFunc("/api/personas", handlers.ListPersonasHandler).Methods("GET")
 	r.HandleFunc("/api/formats", handlers.ListFormatsHandler).Methods("GET")
 	r.HandleFunc("/api/author-style/seed", handlers.SeedAuthorStyleHandler).Methods("POST")

--- a/internal/handlers/config.go
+++ b/internal/handlers/config.go
@@ -1,0 +1,209 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	storageDriverJSON   = "json"
+	storageDriverSQLite = "sqlite"
+)
+
+var activeWorkflowStorage = workflowStorageConfig{
+	Driver: storageDriverJSON,
+	Path:   "data/workflow_store.json",
+	Source: "default",
+}
+
+var workflowStorageMu sync.RWMutex
+
+type workflowStorageConfig struct {
+	Driver string
+	Path   string
+	Source string
+}
+
+type persistedAppConfig struct {
+	WorkflowStoreDriver string `json:"workflow_store_driver"`
+	WorkflowStorePath   string `json:"workflow_store_path"`
+}
+
+type storageConfigRequest struct {
+	WorkflowStoreDriver string `json:"workflow_store_driver"`
+	WorkflowStorePath   string `json:"workflow_store_path"`
+}
+
+type storageConfigResponse struct {
+	ActiveDriver      string `json:"active_driver"`
+	ActivePath        string `json:"active_path"`
+	ConfiguredDriver  string `json:"configured_driver"`
+	ConfiguredPath    string `json:"configured_path"`
+	ConfigPath        string `json:"config_path"`
+	EnvLocked         bool   `json:"env_locked"`
+	RestartRequired   bool   `json:"restart_required"`
+	RestartMessage    string `json:"restart_message"`
+	EffectiveNextBoot bool   `json:"effective_next_boot"`
+}
+
+// GetStorageConfigHandler returns the current and next-boot workflow storage config.
+func GetStorageConfigHandler(w http.ResponseWriter, r *http.Request) {
+	respondWithJSON(w, http.StatusOK, currentStorageConfigResponse())
+}
+
+// UpdateStorageConfigHandler writes the next-boot workflow storage config.
+func UpdateStorageConfigHandler(w http.ResponseWriter, r *http.Request) {
+	if storageEnvLocked() {
+		respondWithError(w, "STORAGE_CONFIG_LOCKED", "Storage config is locked by environment variables", "", http.StatusConflict)
+		return
+	}
+	var req storageConfigRequest
+	if err := decodeJSONRequest(r, &req); err != nil {
+		respondWithError(w, "INVALID_REQUEST_FORMAT", "Invalid request body", "", http.StatusBadRequest)
+		return
+	}
+	driver, path, err := normalizeWorkflowStorage(req.WorkflowStoreDriver, req.WorkflowStorePath)
+	if err != nil {
+		respondWithError(w, "INVALID_STORAGE_CONFIG", "Invalid storage config", err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := writePersistedAppConfig(persistedAppConfig{
+		WorkflowStoreDriver: driver,
+		WorkflowStorePath:   path,
+	}); err != nil {
+		respondWithError(w, "STORAGE_CONFIG_SAVE_FAILED", "Failed to save storage config", err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondWithJSON(w, http.StatusOK, currentStorageConfigResponse())
+}
+
+func currentStorageConfigResponse() storageConfigResponse {
+	active := getActiveWorkflowStorage()
+	configured := resolveNextBootWorkflowStorage()
+	restartRequired := active.Driver != configured.Driver || active.Path != configured.Path
+	message := "現在の保存先で動作中です。"
+	if restartRequired {
+		message = "保存方式の変更はサーバー再起動後に反映されます。"
+	}
+	return storageConfigResponse{
+		ActiveDriver:      active.Driver,
+		ActivePath:        active.Path,
+		ConfiguredDriver:  configured.Driver,
+		ConfiguredPath:    configured.Path,
+		ConfigPath:        appConfigPath(),
+		EnvLocked:         storageEnvLocked(),
+		RestartRequired:   restartRequired,
+		RestartMessage:    message,
+		EffectiveNextBoot: !restartRequired,
+	}
+}
+
+func resolveWorkflowStorageConfig() workflowStorageConfig {
+	if driver := strings.TrimSpace(os.Getenv("WORKFLOW_STORE_DRIVER")); driver != "" {
+		path := strings.TrimSpace(os.Getenv("WORKFLOW_STORE_PATH"))
+		normalizedDriver, normalizedPath, err := normalizeWorkflowStorage(driver, path)
+		if err != nil {
+			return workflowStorageConfig{Driver: driver, Path: path, Source: "env-invalid"}
+		}
+		return workflowStorageConfig{Driver: normalizedDriver, Path: normalizedPath, Source: "env"}
+	}
+	configured := resolveNextBootWorkflowStorage()
+	if configured.Source == "default" && strings.TrimSpace(os.Getenv("WORKFLOW_STORE_PATH")) != "" {
+		path := strings.TrimSpace(os.Getenv("WORKFLOW_STORE_PATH"))
+		_, normalizedPath, err := normalizeWorkflowStorage(storageDriverJSON, path)
+		if err != nil {
+			return workflowStorageConfig{Driver: storageDriverJSON, Path: path, Source: "env-path-invalid"}
+		}
+		return workflowStorageConfig{Driver: storageDriverJSON, Path: normalizedPath, Source: "env-path"}
+	}
+	return configured
+}
+
+func resolveNextBootWorkflowStorage() workflowStorageConfig {
+	config, ok := readPersistedAppConfig()
+	if !ok {
+		return workflowStorageConfig{Driver: storageDriverJSON, Path: "data/workflow_store.json", Source: "default"}
+	}
+	driver, path, err := normalizeWorkflowStorage(config.WorkflowStoreDriver, config.WorkflowStorePath)
+	if err != nil {
+		return workflowStorageConfig{Driver: storageDriverJSON, Path: "data/workflow_store.json", Source: "config-invalid"}
+	}
+	return workflowStorageConfig{Driver: driver, Path: path, Source: "config"}
+}
+
+func normalizeWorkflowStorage(driver, path string) (string, string, error) {
+	driver = strings.ToLower(strings.TrimSpace(driver))
+	switch driver {
+	case "", storageDriverJSON:
+		driver = storageDriverJSON
+		if strings.TrimSpace(path) == "" {
+			path = "data/workflow_store.json"
+		}
+	case storageDriverSQLite:
+		if strings.TrimSpace(path) == "" {
+			path = "data/workflow_store.db"
+		}
+	default:
+		return "", "", fmt.Errorf("workflow_store_driver must be json or sqlite")
+	}
+	return driver, filepath.Clean(strings.TrimSpace(path)), nil
+}
+
+func setActiveWorkflowStorage(config workflowStorageConfig) {
+	workflowStorageMu.Lock()
+	defer workflowStorageMu.Unlock()
+	activeWorkflowStorage = config
+}
+
+func getActiveWorkflowStorage() workflowStorageConfig {
+	workflowStorageMu.RLock()
+	defer workflowStorageMu.RUnlock()
+	return activeWorkflowStorage
+}
+
+func storageEnvLocked() bool {
+	return strings.TrimSpace(os.Getenv("WORKFLOW_STORE_DRIVER")) != ""
+}
+
+func appConfigPath() string {
+	if path := strings.TrimSpace(os.Getenv("NOTE_MAKER_CONFIG_PATH")); path != "" {
+		return filepath.Clean(path)
+	}
+	return "data/app_config.json"
+}
+
+func readPersistedAppConfig() (persistedAppConfig, bool) {
+	encoded, err := os.ReadFile(appConfigPath())
+	if err != nil {
+		return persistedAppConfig{}, false
+	}
+	var config persistedAppConfig
+	if err := json.Unmarshal(encoded, &config); err != nil {
+		return persistedAppConfig{}, false
+	}
+	return config, true
+}
+
+func writePersistedAppConfig(config persistedAppConfig) error {
+	path := appConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create app config dir: %w", err)
+	}
+	encoded, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode app config: %w", err)
+	}
+	tempPath := path + ".tmp"
+	if err := os.WriteFile(tempPath, append(encoded, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write app config temp: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace app config: %w", err)
+	}
+	return nil
+}

--- a/internal/handlers/config_test.go
+++ b/internal/handlers/config_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStorageConfigHandlersPersistNextBootSQLite(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "app_config.json")
+	t.Setenv("NOTE_MAKER_CONFIG_PATH", configPath)
+	t.Setenv("WORKFLOW_STORE_PATH", "")
+	setActiveWorkflowStorage(workflowStorageConfig{Driver: storageDriverJSON, Path: "data/workflow_store.json", Source: "test"})
+
+	body := `{"workflow_store_driver":"sqlite","workflow_store_path":"data/custom.db"}`
+	request := httptest.NewRequest(http.MethodPatch, "/api/config/storage", strings.NewReader(body))
+	response := httptest.NewRecorder()
+
+	UpdateStorageConfigHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var payload storageConfigResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.ConfiguredDriver != storageDriverSQLite || payload.ConfiguredPath != "data/custom.db" {
+		t.Fatalf("unexpected configured storage: %#v", payload)
+	}
+	if !payload.RestartRequired {
+		t.Fatalf("restart_required = false, payload = %#v", payload)
+	}
+
+	getResponse := httptest.NewRecorder()
+	GetStorageConfigHandler(getResponse, httptest.NewRequest(http.MethodGet, "/api/config/storage", nil))
+	if getResponse.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", getResponse.Code, getResponse.Body.String())
+	}
+	var fetched storageConfigResponse
+	if err := json.NewDecoder(getResponse.Body).Decode(&fetched); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if fetched.ConfiguredDriver != storageDriverSQLite || fetched.ConfiguredPath != "data/custom.db" {
+		t.Fatalf("unexpected fetched storage: %#v", fetched)
+	}
+}
+
+func TestStorageConfigHandlerRejectsEnvLockedUpdate(t *testing.T) {
+	t.Setenv("WORKFLOW_STORE_DRIVER", "sqlite")
+	request := httptest.NewRequest(http.MethodPatch, "/api/config/storage", strings.NewReader(`{"workflow_store_driver":"json"}`))
+	response := httptest.NewRecorder()
+
+	UpdateStorageConfigHandler(response, request)
+
+	assertErrorResponse(t, response, http.StatusConflict, "STORAGE_CONFIG_LOCKED")
+}
+
+func TestStorageConfigHandlerRejectsInvalidDriver(t *testing.T) {
+	t.Setenv("WORKFLOW_STORE_DRIVER", "")
+	request := httptest.NewRequest(http.MethodPatch, "/api/config/storage", strings.NewReader(`{"workflow_store_driver":"mysql"}`))
+	response := httptest.NewRecorder()
+
+	UpdateStorageConfigHandler(response, request)
+
+	assertErrorResponse(t, response, http.StatusBadRequest, "INVALID_STORAGE_CONFIG")
+}
+
+func TestResolveWorkflowStorageConfigUsesEnvironment(t *testing.T) {
+	t.Setenv("WORKFLOW_STORE_DRIVER", "sqlite")
+	t.Setenv("WORKFLOW_STORE_PATH", "data/env.db")
+
+	config := resolveWorkflowStorageConfig()
+
+	if config.Driver != storageDriverSQLite || config.Path != "data/env.db" || config.Source != "env" {
+		t.Fatalf("unexpected env config: %#v", config)
+	}
+}
+
+func TestResolveWorkflowStorageConfigUsesJSONPathEnvironment(t *testing.T) {
+	t.Setenv("WORKFLOW_STORE_DRIVER", "")
+	t.Setenv("WORKFLOW_STORE_PATH", "data/env.json")
+	t.Setenv("NOTE_MAKER_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	config := resolveWorkflowStorageConfig()
+
+	if config.Driver != storageDriverJSON || config.Path != "data/env.json" || config.Source != "env-path" {
+		t.Fatalf("unexpected env path config: %#v", config)
+	}
+}
+
+func TestNormalizeWorkflowStorageDefaultsPaths(t *testing.T) {
+	driver, path, err := normalizeWorkflowStorage("", "")
+	if err != nil {
+		t.Fatalf("normalize json: %v", err)
+	}
+	if driver != storageDriverJSON || path != "data/workflow_store.json" {
+		t.Fatalf("json default = %s %s", driver, path)
+	}
+
+	driver, path, err = normalizeWorkflowStorage("sqlite", "")
+	if err != nil {
+		t.Fatalf("normalize sqlite: %v", err)
+	}
+	if driver != storageDriverSQLite || path != "data/workflow_store.db" {
+		t.Fatalf("sqlite default = %s %s", driver, path)
+	}
+}

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -40,22 +39,17 @@ type workflowStoreBackend interface {
 }
 
 func newWorkflowStore() workflowStoreBackend {
-	driver := strings.ToLower(strings.TrimSpace(os.Getenv("WORKFLOW_STORE_DRIVER")))
-	if driver == "sqlite" {
-		path := strings.TrimSpace(os.Getenv("WORKFLOW_STORE_PATH"))
-		if path == "" {
-			path = "data/workflow_store.db"
-		}
+	config := resolveWorkflowStorageConfig()
+	setActiveWorkflowStorage(config)
+	if config.Driver == storageDriverSQLite {
+		path := config.Path
 		store, err := sqliterepo.NewWorkflowStore(path)
 		if err == nil {
 			return store
 		}
 		panic(fmt.Sprintf("initialize sqlite workflow store: %v", err))
 	}
-	path := strings.TrimSpace(os.Getenv("WORKFLOW_STORE_PATH"))
-	if path == "" {
-		path = "data/workflow_store.json"
-	}
+	path := config.Path
 	store, err := memory.NewPersistentWorkflowStore(path)
 	if err == nil {
 		return store

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -137,6 +137,44 @@ body {
     font-size: 14px;
 }
 
+.storage-config {
+    margin: 4px 0 14px;
+    padding: 14px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #fbfcfe;
+}
+
+.storage-config .section-heading {
+    margin-top: 0;
+}
+
+.storage-path-field {
+    grid-column: span 2;
+}
+
+.storage-summary {
+    display: grid;
+    gap: 4px;
+    margin-top: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    color: var(--muted);
+    background: var(--surface);
+    font-size: 14px;
+}
+
+.storage-summary.warning {
+    border-color: #fde68a;
+    color: var(--warning);
+    background: var(--warning-bg);
+}
+
+.storage-summary strong {
+    color: var(--text);
+}
+
 .mode-summary strong {
     color: var(--text);
 }

--- a/static/index.html
+++ b/static/index.html
@@ -55,6 +55,26 @@
             <select id="verify-model"></select>
           </div>
         </div>
+        <div class="storage-config">
+          <div class="section-heading">
+            <h3>保存方式</h3>
+            <button id="save-storage-btn" class="secondary-btn" type="button">保存方式を保存</button>
+          </div>
+          <div class="config-grid">
+            <div class="field-row">
+              <label for="storage-driver">保存先</label>
+              <select id="storage-driver">
+                <option value="json">JSONファイル</option>
+                <option value="sqlite">SQLite</option>
+              </select>
+            </div>
+            <div class="field-row storage-path-field">
+              <label for="storage-path">保存パス</label>
+              <input id="storage-path" type="text" autocomplete="off">
+            </div>
+          </div>
+          <div id="storage-summary" class="storage-summary" aria-live="polite"></div>
+        </div>
         <div id="mode-summary" class="mode-summary" aria-live="polite"></div>
 
         <div class="question-config">

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -43,6 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     templateLoading: false,
     templateError: '',
     templateRequestId: 0,
+    storageConfig: null,
     questionTextById: {},
     lastSubmittedAnswer: '',
     answerAbortController: null,
@@ -59,6 +60,10 @@ document.addEventListener('DOMContentLoaded', () => {
     briefModel: document.getElementById('brief-model'),
     draftModel: document.getElementById('draft-model'),
     verifyModel: document.getElementById('verify-model'),
+    storageDriver: document.getElementById('storage-driver'),
+    storagePath: document.getElementById('storage-path'),
+    saveStorage: document.getElementById('save-storage-btn'),
+    storageSummary: document.getElementById('storage-summary'),
     questionConfigList: document.getElementById('question-config-list'),
     addQuestion: document.getElementById('add-question-btn'),
     resetQuestions: document.getElementById('reset-questions-btn'),
@@ -104,6 +109,7 @@ document.addEventListener('DOMContentLoaded', () => {
   renderQuestionConfig();
   initializeModeControls();
   checkModels();
+  loadStorageConfig();
 
   el.personaSelect.addEventListener('change', onPersonaChange);
   el.formatSelect.addEventListener('change', onFormatChange);
@@ -111,6 +117,8 @@ document.addEventListener('DOMContentLoaded', () => {
   el.briefModel.addEventListener('change', saveModelConfig);
   el.draftModel.addEventListener('change', saveModelConfig);
   el.verifyModel.addEventListener('change', saveModelConfig);
+  el.storageDriver.addEventListener('change', onStorageDriverChange);
+  el.saveStorage.addEventListener('click', saveStorageConfig);
   el.addQuestion.addEventListener('click', addQuestion);
   el.resetQuestions.addEventListener('click', resetQuestions);
   el.analyzeStyle.addEventListener('click', analyzeStyle);
@@ -759,6 +767,74 @@ document.addEventListener('DOMContentLoaded', () => {
       verify: el.verifyModel.value,
     };
     saveConfig();
+  }
+
+  async function loadStorageConfig() {
+    try {
+      const data = await requestJSON('/api/config/storage');
+      state.storageConfig = data;
+      applyStorageConfig(data);
+    } catch (error) {
+      el.storageSummary.className = 'storage-summary warning';
+      el.storageSummary.textContent = `保存方式を取得できませんでした: ${error.message}`;
+    }
+  }
+
+  function applyStorageConfig(data) {
+    el.storageDriver.value = data.configured_driver || data.active_driver || 'json';
+    el.storagePath.value = data.configured_path || data.active_path || defaultStoragePath(el.storageDriver.value);
+    el.storageDriver.disabled = Boolean(data.env_locked);
+    el.storagePath.disabled = Boolean(data.env_locked);
+    el.saveStorage.disabled = Boolean(data.env_locked);
+    renderStorageSummary(data);
+  }
+
+  function renderStorageSummary(data) {
+    const active = `${storageDriverLabel(data.active_driver)} / ${data.active_path}`;
+    const configured = `${storageDriverLabel(data.configured_driver)} / ${data.configured_path}`;
+    const status = data.env_locked
+      ? '環境変数で固定されています。UIからは変更できません。'
+      : data.restart_required
+        ? data.restart_message
+        : '現在の保存方式で動作中です。';
+    el.storageSummary.className = `storage-summary${data.restart_required ? ' warning' : ''}`;
+    el.storageSummary.innerHTML = `
+      <span>現在: <strong>${escapeHTML(active)}</strong></span>
+      <span>次回起動: <strong>${escapeHTML(configured)}</strong></span>
+      <span>${escapeHTML(status)}</span>
+    `;
+  }
+
+  function onStorageDriverChange() {
+    const currentPath = el.storagePath.value.trim();
+    if (!currentPath || currentPath === defaultStoragePath('json') || currentPath === defaultStoragePath('sqlite')) {
+      el.storagePath.value = defaultStoragePath(el.storageDriver.value);
+    }
+  }
+
+  async function saveStorageConfig() {
+    clearError();
+    try {
+      const data = await requestJSON('/api/config/storage', {
+        method: 'PATCH',
+        body: {
+          workflow_store_driver: el.storageDriver.value,
+          workflow_store_path: el.storagePath.value,
+        },
+      });
+      state.storageConfig = data;
+      applyStorageConfig(data);
+    } catch (error) {
+      showError(`保存方式の保存に失敗しました: ${error.message}`);
+    }
+  }
+
+  function storageDriverLabel(driver) {
+    return driver === 'sqlite' ? 'SQLite' : 'JSONファイル';
+  }
+
+  function defaultStoragePath(driver) {
+    return driver === 'sqlite' ? 'data/workflow_store.db' : 'data/workflow_store.json';
   }
 
   async function loadQuestionTemplate() {


### PR DESCRIPTION
## Summary

- Adds `GET/PATCH /api/config/storage` so the app can show and persist workflow storage settings server-side.
- Adds a settings-panel storage section where users can select JSON or SQLite, edit the path, and see current vs next-boot storage.
- Keeps runtime switching safe: changes are saved to `data/app_config.json` and applied after server restart; env-locked configs disable the UI with a clear message.
- Updates README to describe UI storage selection and env override behavior.

## Validation

- `go test ./...`
- `go test ./internal/handlers -cover` -> 80.8%
- `node --check static/js/script.js`
- `git diff --check`

Closes #61
