### PR TITLE
docs: ADR 0003/0004 + Phase D2/E1/E2 implementation plans

### DIFF
--- a/docs/adrs/0002-multi-persona-multi-format-extension.md
+++ b/docs/adrs/0002-multi-persona-multi-format-extension.md
@@ -77,6 +77,8 @@ The two axes compose: any persona can produce any format. The application layer 
 
 ### UX direction
 
+> **Superseded by [ADR 0003 — Conversation-first workspace UI with Alpine.js](0003-conversation-first-workspace-ui.md) (2026-05-03).** Phase A1/A2/A4 shipped chat bubbles, SSE streaming, and deep-dive rationale, but the page-level three-pane layout described below was never implemented. ADR 0003 is now the authoritative source for the UI rewrite. The text below is preserved as design history.
+
 The single-page form becomes a **conversation-first workspace**:
 
 - **Left rail**: persona switcher, project history, "previous style guides" picker.

--- a/docs/adrs/0003-conversation-first-workspace-ui.md
+++ b/docs/adrs/0003-conversation-first-workspace-ui.md
@@ -1,0 +1,174 @@
+# ADR 0003: Conversation-first workspace UI with Alpine.js
+
+Date: 2026-05-03
+
+## Status
+
+Accepted. Supersedes the **UX direction** section of [ADR 0002 §80-86](0002-multi-persona-multi-format-extension.md#ux-direction). All other parts of ADR 0002 (persona, format, persistence, source acquisition, prompt strategy) remain authoritative.
+
+This ADR is implementation-bound: the product baseline already passed end-to-end functional testing on 2026-05-03, but a conversation-first workspace as designed in ADR 0002 was never actually built. This ADR fixes that gap and locks in the framework choice so the rewrite can be parallelized across Cursor, Codex CLI, and final touch-ups.
+
+## Context
+
+ADR 0002 §80-86 explicitly stated:
+
+> The single-page form becomes a **conversation-first workspace**:
+> - Left rail: persona switcher, project history, "previous style guides" picker.
+> - Centre: chat-style transcript. Past answers are clickable and editable.
+> - Right rail (artifact panel): live brief card and live draft preview.
+> - "The conversation feel matches the Claude/ChatGPT/Gemini comparator class."
+
+The 2026-05-03 audit found the actual implementation does not match this:
+
+- `static/index.html` lays out four `<section class="panel">` blocks stacked vertically (Step 0 設定 → Step 1 文体分析 → Step 2 取材 → Step 3 生成と評価) inside a single-column `app-shell` of `width: min(1120px, calc(100% - 32px))`. There is no left or right rail.
+- `static/css/style.css` `.workflow { display: grid; gap: 18px }` is single-column.
+- The chat bubbles (`question-bubble`, `answer-bubble`, `transcript-item` in `static/js/script.js:561-606`) exist but are scoped to the Step 2 panel, not the page-level transcript.
+- The history picker (`#history-persona-select` … `#history-session-select`) is six `<select>` elements stacked inside the Step 0 settings panel. Re-opening a past article requires populating six dropdowns in order rather than clicking one item in a sidebar.
+- `static/js/script.js` is a 3,550-line single file with 93 `getElementById`/`querySelector` calls and 54 `addEventListener` calls; no module split, no reactive store. Three-pane sync would require building one from scratch.
+- Phase A1/A2/A4 (chat transcript, SSE, deep-dive rationale) shipped, but no issue tracked the page-level layout rewrite that ADR 0002 §80-86 implies.
+
+The 13 Playwright E2E tests in `tests/e2e/` lock in DOM ID selectors (`page.locator("#persona-id-input")` etc), so the rewrite must preserve those IDs to keep regression coverage.
+
+## Decision
+
+Adopt **Alpine.js v3** as the UI reactivity layer. Restructure `static/index.html` and `static/css/style.css` into a three-pane CSS Grid layout that matches ADR 0002 §80-86. Decompose `static/js/script.js` into ES modules with an `Alpine.store('app', …)` as the single shared state store. Keep all DOM IDs that the Playwright tests rely on.
+
+### Framework choice rationale
+
+Three options were evaluated against the constraints (preserve existing 13 E2E tests, keep launcher single-binary, minimum delta, support future Wails desktop wrap and Docker LAN serving).
+
+| Option | Pure vanilla refactor | **Alpine.js v3** | React + Vite |
+|---|---|---|---|
+| Build step required | none | none | npm + Vite |
+| Bundle delta | 0 | ~7 kB (alpine.min.js) | 40+ kB |
+| Three-pane reactive sync | self-rolled pub/sub | `Alpine.store()` | React state |
+| Existing 13 E2E impact | none | none (IDs preserved) | rewrite (testid migration) |
+| ETA to ship 3-column workspace | 3-5 days | 4-6 days | ~2 weeks |
+| Compatible with Wails desktop wrap | yes | yes | yes |
+| Compatible with Docker LAN serving | yes | yes | yes |
+
+Alpine.js was chosen because it removes the worst of vanilla's pain (3-pane store-driven sync) without adding the npm/Vite build pipeline that React requires. This aligns with the user's "minimum changes if possible" constraint while still producing the conversation-first feel.
+
+The existing `marked.min.js` is already loaded from CDN, so adding `alpine.min.js` does not change the dependency model — both are single-file vendored libraries. The Alpine version is pinned and committed under `static/vendor/` so the launcher does not depend on internet access at startup.
+
+### Layout target
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ topbar  Note Maker  ·  persona switcher dropdown  ·  model status pill │
+├──────────────┬──────────────────────────────────┬──────────────────────┤
+│ left rail    │ centre transcript                │ right artifact rail  │
+│              │                                  │                      │
+│ ▸ persona    │ [system] 文体ガイドを読み込み中  │ ◇ 文体ガイドカード   │
+│   - terisuke │ [you]    今日は IPv6 移行の話を  │  - 一人称: 僕        │
+│   - cloudia  │ [agent]  読者は誰に届けますか?   │  - 構成パターン      │
+│   + add      │ [you]    社内の DevOps 担当      │  ...                 │
+│              │ [agent]  ストリーミング中...     │                      │
+│ ▸ history    │                                  │ ◇ ブリーフカード     │
+│   conversation│ [input] あなたの回答を入力...    │  - テーマ            │
+│   item list  │  [送信] [停止] [深掘り skip]     │  - 読者              │
+│              │                                  │  ...                 │
+│ ⚙ 詳細設定   │                                  │ ◇ 下書きプレビュー   │
+│              │                                  │  ...                 │
+└──────────────┴──────────────────────────────────┴──────────────────────┘
+```
+
+CSS Grid:
+
+```css
+.workspace { display: grid; grid-template-columns: 240px 1fr 360px; }
+@media (max-width: 1024px) { .workspace { grid-template-columns: 1fr; } }
+```
+
+### State model
+
+Single `Alpine.store('app', …)` with these slices:
+
+- `personas`: `{ list, selectedId }`
+- `formats`: `{ list, selectedId }`
+- `transcript`: `{ items, streamState }`
+- `artifacts`: `{ styleGuide, brief, draft, draftEvaluation, sourceSnapshot }`
+- `history`: `{ articles, selectedArticleId }`
+- `config`: `{ models, storage, customQuestions }` (lives in the settings drawer)
+- `runtime`: `{ modelStatusPill, fallbackHealth }`
+
+Server interaction stays at the existing JSON / SSE endpoints (`internal/handlers/*.go`); the API is unchanged. Handlers remain the JSON boundary; UI restructuring does not move business logic into the frontend.
+
+### Components
+
+Each region is implemented as an Alpine component (one HTML region with `x-data` plus a small JS module that defines the component).
+
+- `personaSwitcher` — top bar dropdown + "+ Add persona" modal trigger
+- `historySidebar` — left rail conversation list (one article = one item, replaces six `<select>`)
+- `transcriptPane` — centre scrollable transcript with bubble groups
+- `composer` — input box, send/cancel/skip-deep-dive controls, format-aware
+- `artifactRail` — right rail with collapsible style guide / brief / draft cards
+- `settingsDrawer` — slide-over panel that hosts model selectors, storage mode, custom-question CRUD (退避先)
+- `personaForm` — modal for create / edit / delete custom persona
+
+Each component file lives at `static/js/components/<name>.js` and imports a shared `static/js/store.js`. Use ES module `<script type="module">`.
+
+### Test preservation
+
+The 13 Playwright tests in `tests/e2e/` reference DOM IDs:
+
+```
+#persona-select, #add-persona-btn, #edit-persona-btn, #delete-persona-btn,
+#add-persona-form, #persona-id-input, #persona-display-name-input,
+#persona-default-format-select, #persona-description-input,
+#persona-source-kind-input, #persona-source-ref-input, #save-persona-btn,
+#format-select, #style-model, #brief-model, #draft-model, #verify-model,
+#storage-driver, #storage-path, #save-storage-btn,
+#refresh-history-btn, #history-persona-select, #history-project-select,
+#history-article-select, #history-draft-select, #history-style-select,
+#history-session-select, #open-history-btn, #clear-history-selection-btn,
+#analyze-style-btn, #use-preset-style-btn, #style-username, #style-limit,
+#start-interview-btn, #answer-input, #submit-answer-btn,
+#cancel-answer-btn, #skip-deep-dive-btn, #generate-draft-btn,
+#cancel-draft-btn, #copy-btn, #copy-preview-btn,
+#regenerate-section-btn, #section-candidate-output,
+#accept-section-btn, #reject-section-btn,
+#brief-card, #brief-preview, #style-guide-card, #guide-preview,
+#preview-content, #markdown-output, #evaluation-summary,
+#verification-summary, #model-status, #loading, #error-message-area,
+#question-log, #section-status, #section-candidate
+```
+
+All existing IDs must remain attached to a DOM element with the same role. IDs may move between regions (e.g., `#refresh-history-btn` moves from settings into the left rail) but must not be deleted. New regions add new IDs; removed regions are not allowed unless the corresponding test is updated in the same PR.
+
+## Out of scope
+
+- SPA framework migration (React, Vue, Svelte). A future ADR may revisit this if Alpine clearly limits scope.
+- Mobile-native build (Capacitor, React Native). Mobile is handled by the responsive breakpoint only.
+- TypeScript adoption. The ES-module split makes TypeScript a future-compatible follow-up but is not required by this ADR.
+- Visual redesign beyond layout structure. Existing colors, typography, and component visuals stay; only the spatial arrangement changes.
+- Streaming protocol changes. SSE endpoints and cancel semantics from Phase A2 stay.
+- Multi-user data isolation. That is owned by [ADR 0004](0004-three-tier-deployment.md).
+
+## Consequences
+
+Positive:
+
+- Conversation feel matches ADR 0002 §80-86 and the user's stated comparators (Claude / ChatGPT / Gemini).
+- Three-pane layout exposes brief card and draft preview during the interview, eliminating the "scroll to see what changed" friction.
+- Module split makes future feature work (search, multi-conversation, settings deep-dive) a localized change instead of a 3,500-line single-file edit.
+- Alpine.store keeps state predictable, which is a prerequisite for the Wails desktop wrap (single-process state) and the Docker LAN deployment (stateless reload).
+- Existing E2E coverage stays green throughout the rewrite if IDs are preserved.
+
+Negative:
+
+- Adds one runtime dependency (`alpine.min.js`, ~7 kB, vendored). Mitigated by version pinning and offline vendoring.
+- Component file count rises from 1 (`script.js`) to ~7. Mitigated by clear directory structure and module discipline.
+- Settings drawer pattern hides model selectors and storage mode behind a button click. Power users may need one extra click to reach those controls; documented in the launcher handoff.
+
+Neutral:
+
+- The framework choice does not constrain Tier 2 (Wails) or Tier 3 (Docker) packaging in [ADR 0004](0004-three-tier-deployment.md).
+
+## References
+
+- [ADR 0002 §UX direction](0002-multi-persona-multi-format-extension.md#ux-direction) — superseded sections.
+- [Alpine.js project page](https://alpinejs.dev/)
+- [Alpine.js GitHub releases](https://github.com/alpinejs/alpine/releases)
+- Implementation plan: [Conversation-first workspace UI](../implementation-plans/conversation-workspace-ui.md)
+- Issue: filed at issue creation time and linked from `docs/implementation-plans/issue-adr-guardrails.md`.

--- a/docs/adrs/0004-three-tier-deployment.md
+++ b/docs/adrs/0004-three-tier-deployment.md
@@ -1,0 +1,116 @@
+# ADR 0004: Three-Tier Deployment Model
+
+Date: 2026-05-03
+
+## Status
+
+Accepted. Extends the near-term execution order recorded in [ADR 0002 §implementation-phases](0002-multi-persona-multi-format-extension.md#phased-rollout). This ADR does not commit to delivery dates; it fixes the architecture so that packaging, desktop distribution, and multi-user hosting can each converge without undoing each other.
+
+## Context
+
+The 2026-05-03 audit found that "distributable desktop app" (Issue [#15](https://github.com/terisuke/note_maker/issues/15)) and "multi-PC LAN web service" were being treated as one problem. They are not.
+
+The existing `scripts/launcher.sh` (lines 1-502) is a developer-ergonomic local launcher:
+
+- It binds to `127.0.0.1` on a dynamically chosen port (line 97 port-check, line 480 app URL).
+- It builds `cmd/server` via `go build` at each start (`scripts/launcher.sh:263-275`).
+- It opens the system browser on the loopback URL (`scripts/launcher.sh:197-205`).
+- It assumes single-user, no authentication, and Tailnet LLM access from the developer's own machine.
+- It stores data under the OS user data directory (macOS: `~/Library/Application Support/Note Maker` at `scripts/launcher.sh:73`, Linux: `$XDG_DATA_HOME/note-maker` at `scripts/launcher.sh:76-77`).
+
+This is complete and correct for its purpose. It shipped in PR #87, which closed Issue [#15](https://github.com/terisuke/note_maker/issues/15).
+
+What the launcher is not:
+
+- It is not a signed, redistributable native application that a non-developer can double-click.
+- It is not a container that a small team can share over a LAN.
+
+Conflating these two missing capabilities with the launcher causes scope creep in every packaging ticket. This ADR names three distinct tiers, assigns separate entry points, and records what is shared and what is not.
+
+## Decision
+
+Adopt a three-tier deployment model with separate entry points but a shared Go handler layer, JSON contract, and repository interfaces.
+
+### Tier matrix
+
+| Attribute | Tier 1 — Launcher | Tier 2 — Wails Desktop | Tier 3 — Multi-user Docker |
+|---|---|---|---|
+| Audience | Developer / project owner | Non-developer single user | Small team (5–15 writers) |
+| Process | bash + `go build` + browser | Single native binary + OS WebView | Container + Tailscale sidecar |
+| Network bind | `127.0.0.1` (loopback) | `127.0.0.1` (in-process) | `0.0.0.0:8080` |
+| Auth | None (loopback trust) | None (loopback trust) | Required; `user_id`-scoped data |
+| Data scope | Single user | Single user | Per-user isolation |
+| LLM transport | Tailnet MagicDNS from host | Tailnet MagicDNS from host | Tailnet MagicDNS through sidecar |
+| Distribution | `git pull` + `make launcher` | Signed binary download | Docker image from GHCR |
+| New work owner | No further work in this ADR | [Tier 2 plan](../implementation-plans/wails-desktop-packaging.md) | [Tier 3 plan](../implementation-plans/multi-user-docker-deployment.md) |
+
+### Tier 1 — Current launcher
+
+Entry point: `scripts/launcher.sh` + `cmd/server/main.go`.
+
+Already shipped as of PR #87. Described fully in [Note Maker app handoff](../handoffs/app-handoff-2026-05-03.md). No further architectural work in this ADR.
+
+### Tier 2 — Wails desktop
+
+Entry point: `cmd/desktop/main.go` (to be created).
+
+A single redistributable binary embedding the existing Go handler code and serving the existing `static/` assets through an OS-native WebView. The binary is 10–20 MB depending on platform, carries no Node.js sidecar, and requires no browser to be open. The installer is signed on macOS (Developer ID) and Windows (code-signing certificate); Linux ships as an AppImage with a checksum.
+
+Framework: [Wails v2](https://wails.io/) stable release. As of 2026-05, Wails v3 is in alpha at [v3alpha.wails.io](https://v3alpha.wails.io/). Wails v3 will be revisited when it reaches a stable release; the architecture of this tier does not depend on v2-specific APIs that would make migration difficult.
+
+Wails was chosen over Electron because the backend is already Go. Wails provides direct Go method bindings to the WebView JavaScript context, eliminating the Node.js sidecar that Electron requires and avoiding the Chromium bundle that inflates Electron app sizes.
+
+The existing static assets, including the Alpine.js-based three-pane workspace introduced by [ADR 0003](0003-conversation-first-workspace-ui.md), are served through Wails without a separate build step. `static/vendor/alpine.min.js` is vendored, so the Wails binary has no runtime internet dependency.
+
+Tier 1 and Tier 2 share the same data directory schema and the same default data directory paths. Upgrading from Tier 1 to Tier 2 requires no data migration.
+
+### Tier 3 — Multi-user Docker
+
+Entry point: `Dockerfile` + `compose.yaml` (to be created).
+
+A container image built from the existing Go server, exposed on `0.0.0.0:8080` for LAN or VPN access. LLM connectivity uses a Tailscale sidecar container that shares the application container's network namespace via `network_mode: service:tailscale`, as described in the [Tailscale Docker guide](https://tailscale.com/blog/docker-tailscale-guide). The application container resolves Evo X2 MagicDNS hostnames (`evo-x2.tailb30e58.ts.net`) through the sidecar's Tailscale tunnel.
+
+Authentication is required. The minimum implementation uses a `TrustedHeaderProvider` that reads `X-Forwarded-User` set by an upstream reverse proxy (Caddy or nginx with OAuth2 Proxy). An OIDC provider implementation (Authentik or Auth0) is a later optional cut.
+
+The largest single ticket for Tier 3 is a data-model migration that adds `user_id TEXT NOT NULL DEFAULT 'local'` to the following SQLite tables: `personas` (custom), `projects`, `articles`, `brief_sessions`, `brief_answers`, `drafts`, `writing_style_guides`, and `author_sources`. Built-in personas (`terisuke`, `cloudia`) stay user-agnostic as seed data. All existing rows are backfilled to `user_id = 'local'`. This migration is filed as `0004_user_id.sql` under the existing migrations directory.
+
+Enabling multi-user mode requires `MULTI_USER=1` at startup; the default mode (single user) remains backwards-compatible with Tier 1 and Tier 2.
+
+## Out of scope
+
+- Native mobile (Capacitor, React Native). Mobile access is handled by the responsive breakpoint introduced in ADR 0003 only.
+- Public-internet SaaS. Tier 3 is LAN/VPN scope only.
+- Migration tooling between tiers. Tier 1 to Tier 2 requires no migration. Moving data from Tier 1/2 to Tier 3 is an operations procedure, not a product feature.
+- OIDC provider choice for Tier 3. The auth middleware interface is specified; the concrete provider is left to the operator.
+- Auto-update for any tier.
+- Wails v3 transition. Deferred until v3 reaches a stable release.
+
+## Consequences
+
+Positive:
+
+- Three distinct audiences (developer, solo desktop user, small team) each have a first-class deployment path.
+- The UI rewrite described in [ADR 0003](0003-conversation-first-workspace-ui.md) is independent of all three tiers; it applies to Tier 1 immediately and the static assets are reused unchanged by Tier 2 and Tier 3.
+- Adding a fourth tier (public SaaS) in a future ADR would not require redesigning the existing three.
+
+Negative:
+
+- Three entry points exist in the repository; keeping them consistent requires discipline. Mitigation: the shared handler layer (`internal/handlers/`) and repository interfaces (`internal/infrastructure/repository/`) are the authoritative logic; entry points are thin wrappers.
+- Tier 3 requires a real data-model migration with a `user_id` column. Any missed handler that reads user-scoped data without the `userID` filter is a data-isolation bug. Mitigation: the handler audit cut (E2-7 in the Tier 3 plan) reviews every handler, and a unit test asserts that cross-user reads return zero rows.
+- Wails v3 transition is deferred. If v3 reaches stable before Tier 2 ships, the team will evaluate migration at that point.
+
+Neutral:
+
+- Execution order between Tier 2 and Tier 3 is left to the respective implementation plans. Neither blocks the other. The UI rewrite from ADR 0003 can ship before, during, or after either packaging tier.
+
+## References
+
+- [ADR 0002 §implementation-phases](0002-multi-persona-multi-format-extension.md#phased-rollout)
+- [ADR 0003 — Conversation-first workspace UI with Alpine.js](0003-conversation-first-workspace-ui.md)
+- [Note Maker app handoff 2026-05-03](../handoffs/app-handoff-2026-05-03.md) — Tier 1 baseline
+- [Wails v2 documentation](https://wails.io/)
+- [Wails v3 alpha documentation](https://v3alpha.wails.io/)
+- [Tailscale Docker guide](https://tailscale.com/blog/docker-tailscale-guide)
+- Implementation plan — Tier 2: [Wails desktop packaging](../implementation-plans/wails-desktop-packaging.md)
+- Implementation plan — Tier 3: [Multi-user Docker deployment](../implementation-plans/multi-user-docker-deployment.md)
+- Implementation plan — UI rewrite: [Conversation-first workspace UI](../implementation-plans/conversation-workspace-ui.md)

--- a/docs/implementation-plans/conversation-workspace-ui.md
+++ b/docs/implementation-plans/conversation-workspace-ui.md
@@ -1,0 +1,289 @@
+# Conversation-first workspace UI implementation plan
+
+Date: 2026-05-03
+
+This plan implements [ADR 0003 — Conversation-first workspace UI with Alpine.js](../adrs/0003-conversation-first-workspace-ui.md). It also satisfies the UX direction that [ADR 0002 §UX direction](../adrs/0002-multi-persona-multi-format-extension.md#ux-direction) (lines 80-86) mandated but that was never built.
+
+## Goals
+
+- Restructure `static/index.html` and `static/css/style.css` into a three-pane CSS Grid layout (`240px | 1fr | 360px`) matching the target in ADR 0003.
+- Replace ad-hoc DOM manipulation in `static/js/script.js` with an `Alpine.store('app', …)` as the single shared state source for all panes.
+- Preserve all DOM IDs that the 13 Playwright end-to-end (E2E) tests reference, so that the test suite remains green throughout the rewrite.
+- Ship without adding a build step. No npm, no Vite, no Webpack. Alpine.js and any other new libraries are vendored under `static/vendor/`.
+- Fold model selectors, storage mode, and custom-question CRUD into a settings drawer so the central transcript pane has unobstructed focus.
+
+## Non-goals
+
+These match the out-of-scope section of ADR 0003:
+
+- SPA framework migration (React, Vue, Svelte).
+- Mobile-native build. Mobile is handled by the `@media (max-width: 1024px)` breakpoint only.
+- TypeScript adoption.
+- Visual redesign beyond layout structure. Colors, typography, and component visuals are unchanged.
+- Streaming protocol changes. SSE endpoints and cancel semantics stay.
+- Multi-user data isolation. That is owned by [ADR 0004](../adrs/0004-three-tier-deployment.md) Tier 3.
+
+## Cut sequence
+
+### Cut D2-1: Vendor Alpine.js
+
+Files to touch: `static/vendor/alpine.min.js`, `static/vendor/lockfile.json` (new).
+
+Pin Alpine.js v3 (latest stable as of 2026-05). Download the minified build. Record the SHA-256 digest in `static/vendor/lockfile.json` alongside the pinned version string. Add the `<script defer src="/static/vendor/alpine.min.js"></script>` tag to `static/index.html` before the closing `</body>` tag. Do not activate any `x-data` or `x-init` attributes yet.
+
+Acceptance:
+
+- `static/vendor/alpine.min.js` is present and the SHA-256 in `lockfile.json` matches.
+- The page loads without JavaScript errors in the browser console.
+- All 13 Playwright tests pass unchanged.
+
+E2E expectation: green (no change to DOM structure).
+
+Delegation: Cursor-friendly. Mechanical file addition with no logic.
+
+---
+
+### Cut D2-2: Introduce `static/js/store.js`
+
+Files to touch: `static/js/store.js` (new), `static/index.html`, `static/js/script.js`.
+
+Create `static/js/store.js` as an ES module that registers `Alpine.store('app', …)` with the seven slices defined in ADR 0003: `personas`, `formats`, `transcript`, `artifacts`, `history`, `config`, `runtime`. Rewire approximately five of the most-used event handlers in `script.js` to read and write through the store as a proof-of-life. Choose handlers that already have clear input/output boundaries (for example, the persona-select change handler and the model-status update path).
+
+Load `store.js` with `<script type="module" src="/static/js/store.js"></script>` in `static/index.html`. The Alpine `defer` script must load before the module scripts to ensure the store registration fires before any component reads it.
+
+No visible UI change in this cut.
+
+Acceptance:
+
+- Opening the browser console shows `Alpine.store('app')` returns the expected shape.
+- The five rewired handlers continue to behave identically to before.
+- All 13 Playwright tests pass.
+
+E2E expectation: green.
+
+Delegation: Codex CLI-friendly. Store shape is fully specified in ADR 0003; wiring five handlers is repetitive.
+
+---
+
+### Cut D2-3: Three-pane CSS Grid scaffold
+
+Files to touch: `static/css/style.css`, `static/index.html`.
+
+Replace the `.workflow { display: grid; gap: 18px }` single-column grid with a `.workspace` container:
+
+```css
+.workspace {
+  display: grid;
+  grid-template-columns: 240px 1fr 360px;
+  gap: 0;
+  height: calc(100vh - 48px); /* subtract topbar height */
+}
+@media (max-width: 1024px) {
+  .workspace { grid-template-columns: 1fr; }
+}
+```
+
+Move the existing four `<section class="panel">` blocks into three grid regions. Keep their content and IDs completely unchanged; only the spatial container changes. The `.app-shell` wrapper around `width: min(1120px, calc(100% - 32px))` is replaced by the full-width `.workspace` grid.
+
+Acceptance:
+
+- The three-column layout renders in a viewport wider than 1024px.
+- All existing panel content is visible and reachable.
+- All 13 Playwright tests pass.
+
+E2E expectation: green. This is the highest-risk cut for test breakage; run the full suite before merging.
+
+Delegation: needs human judgment. Layout decisions (which existing panel goes into which region, overflow behavior) are not purely mechanical.
+
+---
+
+### Cut D2-4: Left-rail history sidebar
+
+Files to touch: `static/index.html`, `static/js/components/historySidebar.js` (new), `static/js/store.js`.
+
+Replace the six `<select>` history pickers (`#history-persona-select`, `#history-project-select`, `#history-article-select`, `#history-draft-select`, `#history-style-select`, `#history-session-select`) with a single conversation-list view in the left rail. The original six selects are wrapped in a `<details>` element with summary text "詳細選択" and remain in the DOM. This keeps Playwright tests that interact with those IDs fully functional and also documents the migration path for any operator tooling that references them.
+
+The new conversation list calls the existing `/api/history` endpoint and the project/article endpoints (`GET /api/projects`, `GET /api/articles/{id}`) introduced in ADR 0002. Clicking a conversation item populates the `history` store slice and fires the same logic that `#open-history-btn` currently fires.
+
+`#refresh-history-btn` is moved from the settings panel into the left-rail header. The `id` attribute stays on the element.
+
+Acceptance:
+
+- Clicking a conversation item in the list opens the corresponding session (transcript, brief card, draft).
+- `#refresh-history-btn` click in the new location still triggers a history refresh.
+- The `<details>詳細選択</details>` fallback reveals all six original selects.
+- All 13 Playwright tests pass (they interact with the selects inside `<details>` and with `#refresh-history-btn`, both of which remain in the DOM).
+
+E2E expectation: green.
+
+Delegation: Codex CLI-friendly. The API calls are already implemented; the component is mostly HTML restructuring driven by the store.
+
+---
+
+### Cut D2-5: Right-rail artifact panel
+
+Files to touch: `static/index.html`, `static/js/components/artifactRail.js` (new), `static/js/store.js`.
+
+Pin `#brief-card`, `#style-guide-card`, and a new `#draft-preview-card` to the right rail. The card elements are moved within the page; their `id` attributes stay on the same DOM elements. Each card subscribes to the corresponding `artifacts` store slice and updates when the slice changes. The existing card rendering logic (brief card, style-guide card) is extracted into `artifactRail.js`; the inline script calls in `script.js` that currently update those elements are replaced by store mutations.
+
+`#draft-preview-card` wraps the existing `#preview-content` div and updates when `artifacts.draft` changes.
+
+Acceptance:
+
+- Brief card updates during the interview phase without a page scroll.
+- Style-guide card is visible in the right rail when a guide is loaded.
+- Draft preview card shows the current draft after generation.
+- `#brief-card`, `#brief-preview`, `#style-guide-card`, `#guide-preview`, and `#preview-content` IDs remain on their elements.
+- All 13 Playwright tests pass.
+
+E2E expectation: green.
+
+Delegation: Codex CLI-friendly. Mechanical element relocation; store subscription pattern is established by D2-2.
+
+---
+
+### Cut D2-6: Centre transcript
+
+Files to touch: `static/index.html`, `static/js/components/transcriptPane.js` (new), `static/js/components/composer.js` (new), `static/js/store.js`.
+
+Promote `#question-log` from the Step 2 panel to the page-level central pane. The element retains its `id` and its existing CSS classes. The central column is a flex column: `#question-log` occupies the scrollable upper portion; the composer (`#answer-input`, `#submit-answer-btn`, `#cancel-answer-btn`, `#skip-deep-dive-btn`) sticks to the bottom.
+
+The Step 2 panel header and any remaining controls that are not the transcript or composer are folded into the settings drawer (Cut D2-7). `#start-interview-btn` and `#generate-draft-btn` move to the topbar or to the composer area; their IDs stay attached.
+
+`transcriptPane.js` manages scroll-to-bottom behavior and bubble rendering. `composer.js` manages the input state and button enabled/disabled logic, reading from `transcript.streamState`.
+
+Acceptance:
+
+- The transcript is the default focused region when the app loads.
+- New messages append at the bottom and the pane auto-scrolls.
+- `#question-log`, `#answer-input`, `#submit-answer-btn`, `#cancel-answer-btn`, `#skip-deep-dive-btn` retain their IDs and remain accessible.
+- All 13 Playwright tests pass.
+
+E2E expectation: green.
+
+Delegation: needs human judgment for the composer layout and the placement of `#start-interview-btn` / `#generate-draft-btn` within the topbar or composer area.
+
+---
+
+### Cut D2-7: Settings drawer
+
+Files to touch: `static/index.html`, `static/js/components/settingsDrawer.js` (new), `static/css/style.css`.
+
+Create a slide-over drawer triggered by a gear icon (`⚙ 詳細設定`) in the topbar. The drawer contains: model selectors (`#style-model`, `#brief-model`, `#draft-model`, `#verify-model`), storage mode (`#storage-driver`, `#storage-path`, `#save-storage-btn`), and custom-question CRUD. All those input IDs stay attached to their existing elements; the elements move under the drawer container.
+
+Add `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to the drawer element. Add `aria-label` to the trigger button.
+
+The `#loading` and `#error-message-area` elements stay at the page level (not inside the drawer) so they are visible regardless of drawer state.
+
+Acceptance:
+
+- The drawer opens and closes without a page reload.
+- All model selector IDs and storage IDs remain accessible in the DOM (inside the drawer).
+- `#loading` and `#error-message-area` are visible when triggered regardless of drawer state.
+- All 13 Playwright tests pass.
+
+E2E expectation: green.
+
+Delegation: Cursor-friendly for the HTML structure; Codex CLI-friendly for the ARIA attributes and CSS transition.
+
+---
+
+### Cut D2-8: Polish and accessibility
+
+Files to touch: `static/css/style.css`, `static/index.html`, component JS files as needed.
+
+- Keyboard navigation: Tab order through the three panes must be logical. The drawer must trap focus when open and return focus to the trigger on close.
+- ARIA: Ensure `#model-status` has `role="status"` and `aria-live="polite"`. Ensure `#error-message-area` has `role="alert"`.
+- Focus management: After submitting an answer, focus returns to `#answer-input`.
+- Mobile breakpoint sanity: At widths below 1024px, the single-column layout must not overflow. The right and left rails collapse; a toggle button exposes each.
+- Visual regression review: Run a manual side-by-side comparison of the before/after screenshots recorded during D2-3.
+
+Acceptance:
+
+- Tab navigation reaches every interactive element without requiring a mouse.
+- VoiceOver / NVDA announces the model status pill and error messages automatically.
+- The mobile single-column layout passes a manual review at 375px viewport width.
+- All 13 Playwright tests pass.
+
+E2E expectation: green.
+
+Delegation: needs human judgment for focus management decisions and mobile layout review.
+
+---
+
+## Shared scaffolding appendix
+
+### `static/vendor/alpine.min.js` provenance
+
+Download from the official Alpine.js GitHub releases (`https://github.com/alpinejs/alpine/releases`). Pin to a specific version tag (for example `v3.x.y`). Record the version and SHA-256 in `static/vendor/lockfile.json`:
+
+```json
+{
+  "alpine.min.js": { "version": "3.x.y", "sha256": "<digest>" },
+  "marked.min.js": { "version": "x.y.z", "sha256": "<digest>" }
+}
+```
+
+### `static/js/store.js` skeleton
+
+```js
+document.addEventListener('alpine:init', () => {
+  Alpine.store('app', {
+    personas:  { list: [], selectedId: null },
+    formats:   { list: [], selectedId: null },
+    transcript:{ items: [], streamState: 'idle' },
+    artifacts: { styleGuide: null, brief: null, draft: null, draftEvaluation: null, sourceSnapshot: null },
+    history:   { articles: [], selectedArticleId: null },
+    config:    { models: {}, storage: {}, customQuestions: [] },
+    runtime:   { modelStatusPill: '', fallbackHealth: {} },
+  });
+});
+```
+
+### Expected directory tree under `static/js/`
+
+```
+static/js/
+  store.js
+  script.js          (retained; shrinks as cuts migrate handlers to components)
+  components/
+    historySidebar.js
+    transcriptPane.js
+    composer.js
+    artifactRail.js
+    settingsDrawer.js
+    personaSwitcher.js
+    personaForm.js
+```
+
+### Migration of `marked.min.js`
+
+`marked.min.js` is currently loaded from a CDN reference in `static/index.html`. In Cut D2-1 or immediately after, download the pinned version to `static/vendor/marked.min.js`, update the `<script>` tag to `/static/vendor/marked.min.js`, and add its SHA-256 to `lockfile.json`. This ensures the Wails desktop build (Tier 2) and Docker container (Tier 3) have no runtime internet dependency for UI scripts.
+
+---
+
+## Validation baseline
+
+Run after each cut before merging:
+
+```
+go test ./...
+python3 -m pytest tests/e2e -q
+./scripts/check-launcher.sh
+git diff --check
+```
+
+---
+
+## Delegation matrix
+
+| Cut | Best owner | Reason |
+|---|---|---|
+| D2-1: Vendor Alpine.js | Cursor | Mechanical file addition; no logic |
+| D2-2: Introduce store.js | Codex CLI | Store shape fully specified; handler wiring is repetitive |
+| D2-3: Three-pane CSS Grid | Human judgment | Layout region assignment requires visual review |
+| D2-4: Left-rail history sidebar | Codex CLI | API calls exist; component is HTML restructuring driven by store |
+| D2-5: Right-rail artifact panel | Codex CLI | Established store subscription pattern; element relocation |
+| D2-6: Centre transcript | Human judgment for layout | Composer placement and button relocation require visual decisions |
+| D2-7: Settings drawer | Cursor (HTML) + Codex CLI (ARIA/CSS) | Clear spec; ARIA attributes are mechanical |
+| D2-8: Polish and a11y | Human judgment | Focus management and mobile review require manual testing |

--- a/docs/implementation-plans/issue-adr-guardrails.md
+++ b/docs/implementation-plans/issue-adr-guardrails.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-01 (last updated 2026-05-03)
 
-This document maps GitHub issues to [ADR 0001](../adrs/0001-three-phase-local-article-generation.md) and [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) and defines implementation guardrails.
+This document maps GitHub issues to [ADR 0001](../adrs/0001-three-phase-local-article-generation.md), [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md), [ADR 0003](../adrs/0003-conversation-first-workspace-ui.md), and [ADR 0004](../adrs/0004-three-tier-deployment.md) and defines implementation guardrails.
 
 ## Issue Map
 
@@ -67,6 +67,35 @@ The phases in [ADR 0002](../adrs/0002-multi-persona-multi-format-extension.md) (
 - Phase B (Persona / OutputFormat): implemented for built-in personas, five formats, source acquisition, and question templates. Further persona/library expansion should wait for Phase C persistence.
 - Phase C (SQLite store): repository interfaces stay; only implementations change. JSON-file store remains the compatibility path, but storage selection must be visible in the web settings UI rather than hidden behind make/env setup. The current app baseline includes persisted custom personas, custom persona update/delete with reference protection, editable human-readable artifacts, and explicit brief versions.
 - Phase D (Quality): handler tests are mandatory before any further endpoint-heavy UI work lands. Coverage gate: `internal/handlers/workflow.go` ≥ 80 %.
+
+## ADR 0003 / 0004 Phase Map
+
+[ADR 0003](../adrs/0003-conversation-first-workspace-ui.md) supersedes the UX direction in ADR 0002 §80-86 and defines the conversation-first workspace rewrite with Alpine.js. [ADR 0004](../adrs/0004-three-tier-deployment.md) introduces three deployment tiers (launcher / Wails desktop / multi-user Docker).
+
+| Phase | Scope | ADR | Implementation plan | Issue |
+|---|---|---|---|---|
+| D2 | Conversation-first workspace UI rewrite (3-pane layout, Alpine.js, settings drawer) | ADR 0003 | [conversation-workspace-ui.md](./conversation-workspace-ui.md) | [#91](https://github.com/terisuke/note_maker/issues/91) |
+| E1 | Wails desktop packaging (Tier 2) | ADR 0004 §Tier 2 | [wails-desktop-packaging.md](./wails-desktop-packaging.md) | [#92](https://github.com/terisuke/note_maker/issues/92) |
+| E2 | Multi-user Docker deployment (Tier 3) | ADR 0004 §Tier 3 | [multi-user-docker-deployment.md](./multi-user-docker-deployment.md) | [#93](https://github.com/terisuke/note_maker/issues/93) |
+
+Phase D2 guardrails:
+
+- All existing `#id` selectors that the 13 Playwright e2e tests rely on must remain attached to a DOM element with the same role. IDs may move between regions but must not be deleted in the same PR that updates the test.
+- No new build step. Alpine.js is vendored under `static/vendor/`; no npm/Vite/webpack pipeline is introduced.
+- The Go HTTP handler surface and JSON contract are unchanged. UI restructuring does not move business logic into the frontend.
+
+Phase E1 guardrails:
+
+- Wails v2 is the version target until v3 reaches a stable release. Pin the exact tag in `cmd/desktop/go.mod`.
+- The Tier 2 binary uses the same data directory as Tier 1. Migration from launcher to desktop is automatic.
+- Code signing is gated on the project owner providing credentials. Unsigned dev builds are acceptable for early validation.
+
+Phase E2 guardrails:
+
+- Every handler that returns user-scoped data must accept `RepoContext` and pass `userID` to the repository. A grep audit at the end of E2-7 must confirm no handler is missed.
+- The default mode (`MULTI_USER` unset or `0`) preserves Tier 1 / Tier 2 behaviour. Multi-user mode is opt-in.
+- Built-in personas (`terisuke`, `cloudia`) stay user-agnostic. Custom personas gain `user_id`.
+- A two-user Playwright isolation smoke test is mandatory before promoting any multi-user image to GHCR.
 
 ## Architectural Guardrails
 

--- a/docs/implementation-plans/multi-user-docker-deployment.md
+++ b/docs/implementation-plans/multi-user-docker-deployment.md
@@ -1,0 +1,331 @@
+# Multi-user Docker deployment implementation plan
+
+Date: 2026-05-03
+
+This plan implements [ADR 0004 Tier 3](../adrs/0004-three-tier-deployment.md#tier-3--multi-user-docker). It enables a small team of 5–15 writers to share one host running the Note Maker container, with per-user data isolation and Tailscale-mediated LLM access over LAN or VPN.
+
+## Goal
+
+Produce a Docker image and a `compose.yaml` that a team can stand up on a single host. Each authenticated user sees only their own personas, projects, articles, and drafts. LLM traffic routes through a Tailscale sidecar container so all Evo X2 MagicDNS hostnames resolve correctly inside the container network. The deployment scope is LAN or Tailscale VPN only; public-internet access is explicitly out of scope.
+
+## Non-goals
+
+- SaaS or public-internet deployment.
+- Anonymous (unauthenticated) access.
+- Mobile-native clients. The responsive breakpoint from ADR 0003 handles mobile browsers.
+- Billing or usage metering.
+- Federated identity or cross-organizational OIDC. One concrete provider example ships; the interface is pluggable.
+- Tier 1 or Tier 2 changes. The `MULTI_USER=1` flag is off by default; single-user deployments are unaffected.
+
+## Cut sequence
+
+### Cut E2-1: Dockerfile
+
+Files to create: `Dockerfile`.
+
+Multi-stage build:
+
+1. Build stage: `golang:1.22-alpine` base, `go build -o /app/note-maker-server ./cmd/server`, copy `static/` into the build output.
+2. Runtime stage: `gcr.io/distroless/static-debian12` or `alpine:3.20` base, non-root user (`USER 65534:65534`), copy the binary and `static/` from the build stage.
+
+Add `HEALTHCHECK CMD wget -qO- http://localhost:8080/api/models || exit 1` (or `curl` if the base image includes it). Expose port `8080`.
+
+This cut is standalone; it does not depend on any auth work.
+
+Acceptance:
+
+- `docker build -t note-maker:dev .` succeeds.
+- `docker run --rm -p 8080:8080 note-maker:dev` starts and `curl http://localhost:8080/api/models` returns a 200 response.
+- The container runs as a non-root user (`id` shows uid=65534 inside the container).
+- `go test ./...` still passes (no import changes).
+
+Delegation: Codex CLI-friendly. Standard multi-stage Go Dockerfile pattern.
+
+---
+
+### Cut E2-2: compose.yaml
+
+Files to create: `compose.yaml`, `.env.example`.
+
+Define two services:
+
+- `app`: the Note Maker image, volume-mounted at `/var/lib/note-maker` for persistent data, environment variables loaded from `.env` (secrets pattern).
+- `tailscale`: the official `tailscale/tailscale` image as an optional sidecar. The `app` service sets `network_mode: service:tailscale` so it shares the sidecar's network namespace. When the sidecar is present, the app container resolves `evo-x2.tailb30e58.ts.net` through the sidecar's MagicDNS.
+
+Document the Tailscale sidecar pattern with reference to the [Tailscale Docker guide](https://tailscale.com/blog/docker-tailscale-guide).
+
+Provide `.env.example` with all required variable names and placeholder values. Never commit a populated `.env` file.
+
+Acceptance:
+
+- `docker compose up -d` starts both services without errors.
+- `docker compose exec app wget -qO- http://localhost:8080/api/models` returns 200.
+- Removing the `tailscale` service and the `network_mode` line leaves the app running in standalone mode (for teams that do not need Tailscale).
+
+Delegation: Cursor-friendly. Declarative YAML; `.env.example` pattern is mechanical.
+
+---
+
+### Cut E2-3: Tailscale sidecar wiring
+
+Files to touch: `compose.yaml`, `.env.example`.
+
+Add environment variable support for the Tailscale sidecar:
+
+- `TS_AUTHKEY`: Tailscale authentication key (ephemeral, write-only; do not log).
+- `TS_HOSTNAME`: the hostname to register in the Tailnet (for example, `note-maker-team`).
+- `TS_EXTRA_ARGS`: optional extra flags passed to `tailscaled`.
+
+The `app` container's `LLM_BASE_URL` defaults to `http://evo-x2.tailb30e58.ts.net/v1` and resolves through the sidecar's MagicDNS when the sidecar is running. If the sidecar restarts, the app retries LLM calls using the existing fallback chain.
+
+Document the startup sequence: the Tailscale sidecar must be healthy before the app container starts making LLM calls. Use `depends_on: tailscale: condition: service_healthy` in `compose.yaml` and add a Tailscale healthcheck (`tailscale status --json | jq -e .BackendState == "Running"`).
+
+Acceptance:
+
+- `tailscale status` inside the sidecar container shows the Tailnet connection as active.
+- `docker compose exec app curl http://evo-x2.tailb30e58.ts.net/v1/models` returns 200.
+- Restarting the sidecar and waiting for it to recover does not require restarting the app container.
+
+Delegation: Codex CLI-friendly. Environment variable mapping and healthcheck DSL follow documented Tailscale patterns.
+
+---
+
+### Cut E2-4: Auth middleware skeleton
+
+Files to create: `internal/handlers/middleware/auth.go`, `internal/handlers/middleware/auth_test.go`.
+
+Define an `AuthProvider` interface:
+
+```go
+type AuthProvider interface {
+    Principal(r *http.Request) (string, error) // returns userID or error
+}
+```
+
+Implement three providers:
+
+- `TrustedHeaderProvider`: reads `X-Forwarded-User` from the request. This is the minimum implementation for a reverse-proxy-fronted deployment.
+- `OIDCProvider`: placeholder that returns `ErrNotImplemented`; wired in Cut E2-9.
+- `MagicLinkProvider`: placeholder; reserved for a future cut.
+
+Add a `MULTI_USER` environment variable flag to `cmd/server/main.go`. When `MULTI_USER=1`, the server wraps every handler with the selected `AuthProvider` middleware. When unset or `0`, the middleware is a no-op that returns `userID = "local"`, preserving full backwards compatibility with Tier 1 and Tier 2.
+
+Acceptance:
+
+- Unit tests: `TrustedHeaderProvider` returns the header value when present and an error when absent. No-op provider always returns `"local"`.
+- `go test ./internal/handlers/middleware/...` passes.
+- Starting the server without `MULTI_USER=1` behaves identically to today.
+
+Delegation: Codex CLI-friendly. Interface and two concrete implementations are fully specified.
+
+---
+
+### Cut E2-5: Data-model migration — `user_id` column
+
+Files to create: `internal/infrastructure/repository/sqlite/migrations/0004_user_id.sql`.
+
+Add `user_id TEXT NOT NULL DEFAULT 'local'` to the following tables: `personas` (custom rows only; built-in seeds are user-agnostic), `projects`, `articles`, `brief_sessions`, `brief_answers`, `drafts`, `writing_style_guides`, `author_sources`. The migration runs `ALTER TABLE … ADD COLUMN user_id TEXT NOT NULL DEFAULT 'local'` for each table, then `UPDATE … SET user_id = 'local' WHERE user_id = ''` as a backfill guard.
+
+Built-in personas (`terisuke`, `cloudia`) in the seed registry are not stored in the `personas` table; they are compiled in. The migration does not touch them.
+
+Acceptance:
+
+- Running the migration on an existing `workflow_store.db` adds the column without data loss.
+- All existing rows have `user_id = 'local'` after the migration.
+- `go test ./internal/infrastructure/repository/sqlite/...` passes including a restart test that confirms the column persists.
+
+Delegation: Codex CLI-friendly. SQL `ALTER TABLE` migration following the established migration pattern.
+
+---
+
+### Cut E2-6: Repository per-user scoping
+
+Files to touch: `internal/infrastructure/repository/sqlite/` (all repository methods that return user-scoped data), `internal/handlers/middleware/auth.go`.
+
+Every SQLite query that reads user-owned data gains a `userID string` parameter in its repository method signature. A `RepoContext` struct carries the authenticated principal and is injected by the auth middleware (E2-4) into the request context. Repository methods extract `userID` from `RepoContext` rather than accepting it as a direct argument, keeping the call sites clean.
+
+Add an index on `user_id` for the tables modified in E2-5.
+
+Add a unit test that seeds two users (`alice`, `bob`) with separate records and asserts that querying with `alice`'s context returns zero rows for `bob`'s data.
+
+This cut must be developed in tandem with E2-4. Do not merge E2-6 without E2-4 also being complete; the two cuts constitute one functional unit.
+
+Acceptance:
+
+- `go test ./internal/infrastructure/repository/sqlite/...` passes including the cross-user isolation test.
+- No repository method that returns user-scoped rows compiles without a `userID` parameter (enforced by the interface).
+
+Delegation: Codex CLI-friendly for the mechanical signature changes; needs human review after E2-5 to confirm no table is missed.
+
+---
+
+### Cut E2-7: Handler audit
+
+Files to touch: every file in `internal/handlers/`.
+
+Review every handler in `internal/handlers/*.go`. Any handler that returns data scoped to a user (personas, projects, articles, sessions, answers, briefs, drafts, style guides, source snapshots) must receive `RepoContext` from the request context and pass `userID` to the repository call. Handlers that return global data (built-in personas, formats, model status) are unchanged.
+
+Update the Playwright E2E tests in `tests/e2e/` to seed a default `local` user in the test database fixture so the existing 13 tests continue to pass against the per-user-scoped handlers.
+
+Acceptance:
+
+- `go test ./internal/handlers/...` passes with 80%+ coverage (matching the gate from Issue [#29](https://github.com/terisuke/note_maker/issues/29)).
+- `python3 -m pytest tests/e2e -q` passes (13 tests green).
+- A grep for `repo.List`, `repo.Get`, `repo.Create` in handler files shows no call site that lacks a `userID` source.
+
+Delegation: needs human review checkpoint. This is the highest-risk cut; a missed handler is a data-isolation bug. Codex CLI can make the mechanical changes; a human must review the diff before merge.
+
+---
+
+### Cut E2-8: Trusted-header reverse proxy demo
+
+Files to create: `compose.override.proxy.yaml`, `docs/operations/multi-user-quickstart.md`.
+
+Provide an example `compose.override.proxy.yaml` that adds a Caddy or nginx service configured to:
+
+1. Require HTTP Basic Auth or delegate to OAuth2 Proxy.
+2. Set `X-Forwarded-User` to the authenticated username.
+3. Forward requests to the `app` service.
+
+Write a 30-minute quickstart guide in `docs/operations/multi-user-quickstart.md` covering: prerequisites, `docker compose -f compose.yaml -f compose.override.proxy.yaml up -d`, adding a second user, and verifying isolation.
+
+Acceptance:
+
+- Following the quickstart guide from a clean Ubuntu 22.04 host produces a running two-user Note Maker instance within 30 minutes.
+- User A's drafts are not visible to User B.
+- The guide includes a troubleshooting section for the three most common failure modes (Tailscale sidecar not connecting, proxy misconfiguration, volume permission error).
+
+Delegation: Cursor-friendly for the YAML overlay; Codex CLI-friendly for the operations guide prose.
+
+---
+
+### Cut E2-9: OIDC provider implementation
+
+Files to touch: `internal/handlers/middleware/auth.go`, `go.mod`, `go.sum`.
+
+Wire one concrete OIDC provider (suggest Authentik or Auth0 as the documented example, using the `coreos/go-oidc/v3` library). Validate the JWT against the provider's JWKS endpoint. Extract the subject claim as `userID`. Store the session as a short-lived cookie.
+
+This cut is optional and gated on operator readiness. The `TrustedHeaderProvider` from E2-4 remains the recommended path for teams without an existing OIDC provider.
+
+Acceptance:
+
+- Unit test: a valid JWT from a mock OIDC provider is accepted; an expired or tampered JWT is rejected.
+- Integration test: `docker compose up` with Authentik configured returns a valid session cookie after login.
+
+Delegation: Codex CLI-friendly for the library wiring; needs human judgment for provider-specific configuration.
+
+---
+
+### Cut E2-10: Audit log
+
+Files to create: `internal/handlers/middleware/audit.go`, `internal/handlers/middleware/audit_test.go`.
+
+Record every cross-user access attempt (a request where the authenticated `userID` does not match the resource owner) to a structured log. Default output: `/var/log/note-maker/audit.log` in the container (rotated by the Docker logging driver or a log-rotation sidecar). Each log line is a JSON object with: `timestamp`, `request_id`, `user_id`, `resource_type`, `resource_owner_id`, `action`, `result` (`allowed` or `denied`).
+
+Normal (allowed) requests are logged at `INFO` level with result `allowed`. Cross-user attempts are logged at `WARN` with result `denied` and the resource owner's `user_id`.
+
+Acceptance:
+
+- Unit test: the middleware logs a `denied` entry when the authenticated user differs from the resource owner.
+- `docker compose exec app cat /var/log/note-maker/audit.log` shows structured JSON after a test request.
+
+Delegation: Codex CLI-friendly. Structured logging pattern is well-established in the codebase.
+
+---
+
+### Cut E2-11: GHCR publish workflow
+
+Files to create: `.github/workflows/container-publish.yml`.
+
+GitHub Actions workflow that triggers on version tags (`v*.*.*`) and on pushes to `main`. Builds and pushes `ghcr.io/<owner>/note-maker:<tag>` using `docker buildx build --platform linux/amd64,linux/arm64` (multi-arch). Uses `GITHUB_TOKEN` for GHCR authentication; no additional secrets required.
+
+Acceptance:
+
+- Pushing a tag `v0.4.0` triggers the workflow and produces `ghcr.io/terisuke/note-maker:v0.4.0` and `ghcr.io/terisuke/note-maker:latest` in GHCR.
+- The published image runs on both `amd64` and `arm64` hosts.
+- `go test ./...` is run as a pre-publish gate in the workflow.
+
+Delegation: Codex CLI-friendly. Standard GHCR publish workflow.
+
+---
+
+### Cut E2-12: Operations runbook
+
+Files to create: `docs/operations/docker-runbook.md`.
+
+Document the full operations lifecycle:
+
+- **Start**: `docker compose up -d`; confirm health at `/api/models`.
+- **Stop**: `docker compose down`.
+- **Upgrade**: pull the new image, `docker compose pull`, `docker compose up -d`.
+- **Backup**: `docker compose exec app tar czf - /var/lib/note-maker > backup-$(date +%Y%m%d).tar.gz`.
+- **Restore**: stop the container, restore the volume, restart.
+- **Tailscale sidecar troubleshooting**: `docker compose exec tailscale tailscale status`; re-authenticate if the key has expired (`docker compose exec tailscale tailscale login`).
+- **LLM connectivity loss during a request**: the app returns the partial draft with an error annotation; the user can retry. The sidecar restart does not lose in-flight HTTP connections from the app because the app uses the fallback chain.
+
+Acceptance:
+
+- A team member unfamiliar with Docker can complete the upgrade procedure in under 10 minutes by following the runbook.
+- The backup and restore procedure is tested by restoring a backup to a fresh volume and confirming that `GET /api/workflow/artifacts` returns the expected data.
+
+Delegation: Cursor-friendly. Prose documentation with verified command examples.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Cross-user data leak via a missed handler | E2-7 handler audit with a dedicated cross-user isolation unit test and a human review checkpoint. |
+| Tailscale sidecar restarts mid-request | The app's existing fallback chain (`EVO_X2_LLAMA_CPP_LLM_BASE_URL`, then `127.0.0.1:8081`) catches the LLM connectivity loss. Partial drafts are preserved. |
+| Docker volume permission drift (files owned by root inside the container) | Run the app as `uid=65534` in E2-1. Mount volumes with `user: "65534:65534"` in `compose.yaml`. Document the `chown` fix in the runbook. |
+| Sidecar restarts causing LLM connectivity loss mid-request | `depends_on: tailscale: condition: service_healthy` delays app startup. After startup, the fallback chain handles transient sidecar restarts without losing the draft. |
+| Header-trust spoofing if the reverse proxy is misconfigured | Document that `X-Forwarded-User` must only be accepted from the proxy's IP. The Caddy/nginx example in E2-8 includes a `trusted_proxies` directive. Provide a hardening checklist in `docs/operations/multi-user-quickstart.md`. |
+
+## Validation baseline
+
+Run after each cut before merging:
+
+```
+go test ./...
+python3 -m pytest tests/e2e -q
+./scripts/check-launcher.sh
+git diff --check
+```
+
+Tier 3 additional checks:
+
+```
+docker build -t note-maker:dev .
+docker compose up -d && sleep 5 && curl -sf http://localhost:8080/api/models
+docker compose down
+```
+
+Two-user smoke test (to be added to `tests/e2e/` in Cut E2-7):
+
+```
+python3 -m pytest tests/e2e/test_multi_user_isolation.py -q
+```
+
+This Playwright test case seeds user `alice` and user `bob` with separate drafts. It asserts that:
+
+- Logged in as `alice`, `GET /api/drafts` returns only Alice's drafts.
+- Logged in as `bob`, `GET /api/drafts` returns only Bob's drafts.
+- Alice's `draft_id` is not accessible to Bob (returns 404 or 403).
+
+## Delegation matrix
+
+| Cut | Best owner | Reason |
+|---|---|---|
+| E2-1: Dockerfile | Codex CLI | Standard multi-stage Go Dockerfile |
+| E2-2: compose.yaml | Cursor | Declarative YAML; `.env.example` pattern |
+| E2-3: Tailscale wiring | Codex CLI | Environment mapping follows documented Tailscale patterns |
+| E2-4: Auth middleware skeleton | Codex CLI | Interface and two implementations fully specified |
+| E2-5: user_id migration | Codex CLI | SQL ALTER TABLE following established migration pattern |
+| E2-6: Repository scoping | Codex CLI + human review | Mechanical signature changes; human confirms no table is missed |
+| E2-7: Handler audit | Human review checkpoint | Missed handler = data-isolation bug; Codex CLI makes changes, human reviews diff |
+| E2-8: Reverse proxy demo | Cursor (YAML) + Codex CLI (guide) | Declarative config + prose |
+| E2-9: OIDC provider | Codex CLI + human judgment | Library wiring is mechanical; provider config requires operator input |
+| E2-10: Audit log | Codex CLI | Structured logging pattern |
+| E2-11: GHCR publish | Codex CLI | Standard GHCR workflow |
+| E2-12: Operations runbook | Cursor | Prose documentation with verified commands |

--- a/docs/implementation-plans/multi-user-docker-deployment.md
+++ b/docs/implementation-plans/multi-user-docker-deployment.md
@@ -25,7 +25,7 @@ Files to create: `Dockerfile`.
 
 Multi-stage build:
 
-1. Build stage: `golang:1.22-alpine` base, `go build -o /app/note-maker-server ./cmd/server`, copy `static/` into the build output.
+1. Build stage: `golang:1.23-alpine` base (matches `go.mod` `go 1.23.0`), `go build -o /app/note-maker-server ./cmd/server`, copy `static/` into the build output.
 2. Runtime stage: `gcr.io/distroless/static-debian12` or `alpine:3.20` base, non-root user (`USER 65534:65534`), copy the binary and `static/` from the build stage.
 
 Add `HEALTHCHECK CMD wget -qO- http://localhost:8080/api/models || exit 1` (or `curl` if the base image includes it). Expose port `8080`.

--- a/docs/implementation-plans/wails-desktop-packaging.md
+++ b/docs/implementation-plans/wails-desktop-packaging.md
@@ -1,0 +1,235 @@
+# Wails desktop packaging implementation plan
+
+Date: 2026-05-03
+
+This plan implements [ADR 0004 Tier 2](../adrs/0004-three-tier-deployment.md#tier-2--wails-desktop). It produces a signed, redistributable single-binary desktop application for macOS, Windows, and Linux, reusing the existing Go handlers and static assets without modification.
+
+## Goal
+
+Ship a Wails v2 desktop build of Note Maker that a non-developer can install and run without `git`, `go`, or a running browser. The binary embeds the same `internal/handlers/` code and serves the same `static/` assets that Tier 1 (the launcher) uses. Tier 1 data directories are shared, so moving from the launcher to the desktop app requires no data migration.
+
+## Non-goals
+
+- Mobile (iOS, Android). Mobile access is the responsive breakpoint only.
+- Auto-update on first ship. The binary can be replaced manually; an auto-update mechanism is a separate future cut.
+- Custom branding and icons beyond a placeholder icon. A production-quality icon set is a separate design task.
+- Multi-user mode. That is Tier 3 ([ADR 0004 §Tier 3](../adrs/0004-three-tier-deployment.md#tier-3--multi-user-docker)).
+- Wails v3 migration. Deferred until Wails v3 reaches a stable release.
+
+## Wails version pin
+
+Wails v2 latest stable as of 2026-05. This plan will be revisited and updated when Wails v3 reaches a stable release. The v2 API surface used here (`wails.Run`, `runtime.BrowserOpenURL`, menu APIs) has documented equivalents in the v3 alpha; a future migration should not require rewriting the handler layer.
+
+## Cut sequence
+
+### Cut E1-1: Wails v2 scaffolding
+
+Files to create: `cmd/desktop/main.go`, `wails.json`.
+
+Add Wails as a Go module dependency (`go get github.com/wailsapp/wails/v2`). Create `cmd/desktop/main.go` that calls the existing handler setup (the same function that `cmd/server/main.go` calls to register routes) as the Wails app's startup function. Create `wails.json` pointing at `cmd/desktop` as the application entry. Run `wails dev` to confirm the existing UI loads inside the OS WebView (WebKit on macOS and Linux, Microsoft WebView2 (the Chromium-based embedded browser component for Windows, distributed separately from Wails) on Windows).
+
+Files to touch: `go.mod`, `go.sum`, `cmd/desktop/main.go` (new), `wails.json` (new).
+
+Acceptance:
+
+- `wails dev` starts the app and opens the existing UI in the OS WebView without errors.
+- `go test ./...` still passes (no import cycle introduced).
+
+E2E expectation: manual verification that the three-pane workspace from ADR 0003 renders correctly inside the WebView.
+
+Delegation: Codex CLI-friendly. Boilerplate Wails entry point with an existing handler function wired in.
+
+---
+
+### Cut E1-2: Asset pipeline reuse
+
+Files to touch: `wails.json`, `cmd/desktop/main.go`.
+
+Point Wails at the existing `static/` directory rather than generating a new frontend scaffold. In `wails.json`, set the `frontend.dir` to `static` and disable any build-step hooks (no `npm install`, no `npm run build`). The post-ADR-0003 `static/` already contains `vendor/alpine.min.js`, `vendor/marked.min.js`, `js/store.js`, and component files, so Wails treats them as static assets served over the embedded HTTP layer.
+
+Confirm that the `AssetFS` embed in `cmd/desktop/main.go` uses `//go:embed static` or the Wails `assetserver` configuration pointing at the on-disk `static/` directory for `wails dev`, and embedded assets for `wails build`.
+
+Acceptance:
+
+- `wails dev` serves `static/vendor/alpine.min.js` at the expected URL.
+- `wails build` produces a binary that loads the UI without an internet connection.
+- No separate `npm` or build tool is required.
+
+Delegation: Cursor-friendly. Configuration change in `wails.json`.
+
+---
+
+### Cut E1-3: Native windowing and menus
+
+Files to touch: `cmd/desktop/main.go`, `cmd/desktop/menu.go` (new).
+
+Add a minimal native menu bar with three menus:
+
+- **File**: "Open data folder" (opens the Tier 1 data directory in the OS file manager), "Quit".
+- **View**: "Show LLM diagnostics" (mirrors the output of `make launcher-status` in a dialog).
+- **Help**: "About Note Maker" (version string), "Open documentation".
+
+Use the Wails v2 menu API (`runtime.MenuSetApplicationMenu`).
+
+Acceptance:
+
+- "Open data folder" opens `~/Library/Application Support/Note Maker` on macOS and the corresponding XDG path on Linux.
+- "Show LLM diagnostics" displays the primary and fallback LLM endpoint health.
+- The app quits cleanly from the File menu without leaving orphan processes.
+
+Delegation: Codex CLI-friendly. Menu API is well-documented and calls existing health-check logic.
+
+---
+
+### Cut E1-4: First-run data directory bootstrap
+
+Files to touch: `cmd/desktop/main.go`.
+
+On first launch, if the data directory does not exist, create it and write the same default `app_config.json` that `scripts/launcher.sh` would write on first run. Use the same OS-conditional path logic (`~/Library/Application Support/Note Maker` on macOS, `$XDG_DATA_HOME/note-maker` or `~/.local/share/note-maker` on Linux, `%APPDATA%\Note Maker` on Windows). This ensures that a user who previously ran the Tier 1 launcher finds their existing data when they first open the Tier 2 desktop binary.
+
+Acceptance:
+
+- On a fresh macOS machine, opening the desktop app creates `~/Library/Application Support/Note Maker/app_config.json` with sane defaults.
+- On a machine that already ran `make launcher`, opening the desktop app reads the existing `app_config.json` without overwriting it.
+
+Delegation: Cursor-friendly. Path logic mirrors `scripts/launcher.sh` lines 59-82.
+
+---
+
+### Cut E1-5: macOS code signing and notarization
+
+Files to touch: `.github/workflows/desktop-release.yml` (new or extended), `Makefile`.
+
+Gate: this cut requires the project owner to provide an Apple Developer ID certificate and an App Store Connect API key for notarization. Without those credentials, unsigned developer builds still work; macOS will show a Gatekeeper warning.
+
+Store signing credentials as GitHub Actions secrets: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_TEAM_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY`.
+
+Use `wails build -platform darwin/amd64` and `wails build -platform darwin/arm64` for Apple Silicon and Intel targets. Run `xcrun notarytool submit` after signing. Produce a universal binary or two separate signed DMGs.
+
+Acceptance:
+
+- The signed macOS DMG opens without a Gatekeeper warning on a clean macOS machine.
+- `xcrun stapler validate` passes on the notarized binary.
+- Unsigned local builds (`RELEASE=0`) still produce a runnable binary; only signing and notarization are gated on credentials.
+
+Delegation: needs human judgment. Signing credential setup and Apple notarization toolchain require the project owner's involvement.
+
+---
+
+### Cut E1-6: Windows code signing and MSI
+
+Files to touch: `.github/workflows/desktop-release.yml`, `Makefile`.
+
+Gate: this cut requires a Windows code-signing certificate (Extended Validation or Organization Validation).
+
+Use `wails build -platform windows/amd64`. Sign the resulting `.exe` with `signtool.exe` or an equivalent CI action. Package into an MSI with a Wails-compatible installer tool (the Wails docs recommend NSIS or WiX for MSI generation).
+
+Acceptance:
+
+- The signed Windows installer runs without a SmartScreen warning on a clean Windows 10/11 machine.
+- Unsigned local builds still produce a runnable `.exe`.
+
+Delegation: needs human judgment. Windows signing credential setup requires the project owner's involvement.
+
+---
+
+### Cut E1-7: Linux AppImage
+
+Files to touch: `.github/workflows/desktop-release.yml`, `Makefile`.
+
+Use `wails build -platform linux/amd64`. Package the binary as an AppImage. No code signing is required; provide a SHA-256 checksum file alongside the AppImage download.
+
+Note: on some Linux distributions, the system WebKit version may be outdated. Document the minimum WebKit version requirement (WebKitGTK 4.0 or later) in `docs/operations/`.
+
+Acceptance:
+
+- The AppImage runs on Ubuntu 22.04 LTS and Fedora 40 without additional dependencies beyond WebKitGTK.
+- A SHA-256 checksum file is published alongside the AppImage.
+
+Delegation: Codex CLI-friendly. Standard AppImage packaging; checksum generation is mechanical.
+
+---
+
+### Cut E1-8: Build pipeline
+
+Files to touch: `.github/workflows/desktop-release.yml`, `Makefile`.
+
+Add a `make desktop-build` target that runs `wails build` for the current platform. Add a GitHub Actions matrix job that runs on `macos-latest`, `windows-latest`, and `ubuntu-latest`, producing three release artifacts. The workflow triggers on version tags (`v*.*.*`).
+
+Set `RELEASE=1` as an environment variable to gate real signing and notarization steps. Without `RELEASE=1`, the workflow builds unsigned binaries for validation.
+
+Acceptance:
+
+- `make desktop-build` produces a runnable binary on the developer's local machine.
+- A GitHub Actions dry run (without signing secrets) produces binaries for all three platforms without errors.
+- A `RELEASE=1` run (with secrets) produces signed artifacts for macOS and Windows.
+
+Delegation: Codex CLI-friendly. Matrix CI configuration is repetitive; the signing steps follow the patterns from E1-5 and E1-6.
+
+---
+
+### Cut E1-9: Smoke test on each platform
+
+Files to create: `docs/validation/wails-desktop-smoke-test.md`.
+
+Manual smoke test procedure documented in `docs/validation/wails-desktop-smoke-test.md`:
+
+1. Install the platform binary.
+2. Confirm the three-pane workspace loads.
+3. Select the `terisuke` persona and start an interview with a stub LLM response.
+4. Confirm the Tailnet LLM status pill shows the expected endpoint.
+5. Confirm "Open data folder" (File menu) opens the correct directory.
+6. Quit the app and confirm no orphan processes remain.
+
+This test must be run by a human on each target platform before a version tag is pushed.
+
+Acceptance:
+
+- All six steps pass on macOS (arm64), Windows 10/11 (amd64), and Ubuntu 22.04 (amd64).
+- Results are recorded in `docs/validation/wails-desktop-smoke-test.md` with platform, binary version, and tester name.
+
+Delegation: human judgment required. Platform-specific verification cannot be automated in CI.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Wails v3 reaches stable before Tier 2 ships | Evaluate migration at that point; v2 API surface used here has v3 equivalents. No lock-in to v2-only APIs. |
+| WebView2 (Microsoft's Chromium-based embedded browser component for Windows) is not installed on older Windows machines | Document the WebView2 prerequisite. Include a bootstrapper in the MSI that installs WebView2 if absent. |
+| WebKit version on older Linux distros renders the UI incorrectly | Document the minimum WebKitGTK 4.0 requirement. Test on Ubuntu 22.04 LTS as the minimum baseline. |
+| Code-signing secrets rotate | Store all secrets in GitHub Actions; document the rotation procedure in `docs/operations/`. Never embed secrets in source. |
+| Unsigned macOS builds warn Gatekeeper before E1-5 | Expected behavior for developer builds. Document the `xattr -d com.apple.quarantine` workaround for testers. |
+
+## Validation baseline
+
+Run after each cut before merging:
+
+```
+go test ./...
+python3 -m pytest tests/e2e -q
+./scripts/check-launcher.sh
+git diff --check
+```
+
+Tier 2 additional checks:
+
+```
+wails build -dry-run   # if supported; otherwise: wails build -platform <current>
+make desktop-build
+```
+
+## Delegation matrix
+
+| Cut | Best owner | Reason |
+|---|---|---|
+| E1-1: Wails scaffolding | Codex CLI | Boilerplate entry point; established handler wiring pattern |
+| E1-2: Asset pipeline reuse | Cursor | `wails.json` configuration change |
+| E1-3: Native menus | Codex CLI | Well-specified menu API; calls existing health-check logic |
+| E1-4: First-run data dir | Cursor | Mirrors existing launcher path logic |
+| E1-5: macOS signing | Human judgment | Requires project owner credentials and Apple toolchain |
+| E1-6: Windows signing | Human judgment | Requires project owner credentials and Windows toolchain |
+| E1-7: Linux AppImage | Codex CLI | Standard packaging; checksum generation is mechanical |
+| E1-8: Build pipeline | Codex CLI | Matrix CI configuration is repetitive |
+| E1-9: Smoke test | Human judgment | Platform-specific manual verification |


### PR DESCRIPTION
Closes #94

## Summary

- ADR 0003 — Conversation-first workspace UI with Alpine.js. Supersedes the UX direction section of ADR 0002.
- ADR 0004 — Three-tier deployment strategy (launcher / Wails desktop / multi-user Docker).
- Phase D2 plan — UI rewrite decomposed into 8 incremental cuts that preserve the 13 existing Playwright e2e selectors. Tracked under issue 91.
- Phase E1 plan — Wails v2 desktop packaging with code-signing matrix. Tracked under issue 92.
- Phase E2 plan — Multi-user Docker deployment with Tailscale sidecar and per-user data isolation. Tracked under issue 93.
- issue-adr-guardrails.md and ADR 0002 are updated with cross-references.

This PR is documentation-only. No code or test changes. Issues 91, 92, 93 remain open after merge so the implementation work can be assigned.

## Test plan

- [x] go test ./... (cached green; no Go files changed)
- [x] python3 -m pytest tests/e2e -q (13 passed; no test files changed)
- [x] git diff --check (clean)
- [x] All four new docs cross-link to ADR 0003 / ADR 0004 / their plans
- [x] ADR 0002 UX direction section shows the supersession banner
- [x] issue-adr-guardrails.md table lists D2 / E1 / E2 with their tracking issues

## Related

- Issue 90 (llama-swap fallback) was filed earlier the same day; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)